### PR TITLE
coding-style suggestions

### DIFF
--- a/CODING-STYLE.md
+++ b/CODING-STYLE.md
@@ -1,0 +1,41 @@
+# Coding Style
+
+We use Linux Kernel Coding Style with a few amendments. These are described in
+the next section.  
+
+The Linux Kernel Coding Style guidelines can be obtained from here:  
+https://www.kernel.org/doc/Documentation/CodingStyle  
+
+
+## Amendments
+
+### Chapter 8. Comments
+#### Paragraph §3
+
+~~When commenting the kernel API functions, please use the kernel-doc format.
+See the files Documentation/kernel-doc-nano-HOWTO.txt and scripts/kernel-doc
+for details.~~
+
+Instead of kernel-doc, we use Doxygen/Javadoc syntax for documenting code.
+
+When commenting PAL API functions, please use the following format.
+
+```c
+/**
+ * Short and to the point one line description.
+ *
+ * Longer text (if needed) describing the function in more detail. It can
+ * span multiple lines and paragraphs.
+ *
+ * @param dest	Destination pointer.
+ * @param src	Source pointer.
+ * @param n	Number of bytes to copy.
+ * @return	A pointer to dest.
+ */
+void *memcpy(void *dest, const void *src, size_t n)
+{
+	...
+}
+
+```
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,9 @@ If you are interested in contributing to PAL, here are some instructions to get 
 started. Thank you!
 
 ### Coding Style
-* "K&R coding style, 4 spaces for tabs"
-* A reference: https://www.kernel.org/doc/Documentation/CodingStyle
+* Linux Kernel Coding Style
+* Doxygen/Javadoc instead of kernel-doc
+* See [CODING-STYLE.md](CODING-STYLE.md)
 
 ### Contribution Conventions
 * If it's a bug fix branch, name it XXXX-something where XXXX is the number of the


### PR DESCRIPTION
Try to stick to vanilla Linux Kernel Coding Style.

It was stupid of me to suggest we use spaces instead of tabs.
Let's try to maintain some kind sanity in the universe by not introducing a
new set of indentation rules.

We should use Doxygen instead of kernel-doc format.

Signed-off-by: Ola Jeppsson ola@adapteva.com
