### PR TITLE
#6 - Fix inconsistency between header/implementation

### DIFF
--- a/src/image/p_conv2d.c
+++ b/src/image/p_conv2d.c
@@ -14,7 +14,7 @@
  *
  */
 
-void p_conv2d_32f(float *x, float *m, int rows, int cols, int msize, float *r)
+void p_conv2d_f32(float *x, float *m, float *r, int rows, int cols, int msize)
 {
 
     /*PLACE CODE HERE*/


### PR DESCRIPTION
Both function name and its arguments' order were differing.
Refers to image/p_conv2d
> another issue reference #6 