### PR TITLE
#8 - math: Fix functions' names across whole module

### DIFF
--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -209,7 +209,7 @@ void p_min_f32(float *a, float *c, int *index, int n);
  */
 
 /*sort an array*/
-void p_sort_32f(float *a, float *c, int n);
+void p_sort_f32(float *a, float *c, int n);
 void p_sort_u32(int *a, int *c, int n);
 
 /* seed pseudo-random number generator */

--- a/src/math/p_abs.c
+++ b/src/math/p_abs.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_abs_32f(const float *a, float *c, int n)
+void p_abs_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_absdiff.c
+++ b/src/math/p_absdiff.c
@@ -16,7 +16,7 @@
  *
  */
 
-void p_absdiff_32f(float *a, float *b, float *c, int n)
+void p_absdiff_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_acos.c
+++ b/src/math/p_acos.c
@@ -16,7 +16,7 @@
  *
  */
 #include <math.h>
-void p_acos_32f(float *a, float *c, int n)
+void p_acos_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_acosh.c
+++ b/src/math/p_acosh.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_acosh_32f(float *a, float *c, int n)
+void p_acosh_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_add.c
+++ b/src/math/p_add.c
@@ -14,7 +14,7 @@
  *
  */
 
-void p_add_32f(float *a, float *b, float *c, int n)
+void p_add_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_asin.c
+++ b/src/math/p_asin.c
@@ -16,7 +16,7 @@
  *
  */
 #include <math.h>
-void p_asin_32f(float *a, float *c, int n)
+void p_asin_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_asinh.c
+++ b/src/math/p_asinh.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_asinh_32f(float *a, float *c, int n)
+void p_asinh_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_atan.c
+++ b/src/math/p_atan.c
@@ -16,7 +16,7 @@
  *
  */
 #include <math.h>
-void p_atan_32f(float *a, float *c, int n)
+void p_atan_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_atan2.c
+++ b/src/math/p_atan2.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_atan2_32f(float *a, float *b, float *c, int n)
+void p_atan2_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_atanh.c
+++ b/src/math/p_atanh.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_atanh_32f(float *a, float *c, int n)
+void p_atanh_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_cbrt.c
+++ b/src/math/p_cbrt.c
@@ -15,7 +15,7 @@
  * @return      None
  *
  */
-void p_cbrt_32f(float *a, float *c, int n)
+void p_cbrt_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_cos.c
+++ b/src/math/p_cos.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_cos_32f(float *a, float *c, int n)
+void p_cos_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_cosh.c
+++ b/src/math/p_cosh.c
@@ -16,7 +16,7 @@
  */
 
 #include <math.h>
-void p_cosh_32f(float *a, float *c, int n)
+void p_cosh_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_div.c
+++ b/src/math/p_div.c
@@ -16,7 +16,7 @@
  *
  */
 
-void p_div_32f(float *a, float *b, float *c, int n)
+void p_div_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_dot.c
+++ b/src/math/p_dot.c
@@ -16,7 +16,7 @@
  * @return      None
  *
  */
-void p_dot_32f(float *a, float *b, float *c, int n)
+void p_dot_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_exp.c
+++ b/src/math/p_exp.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_exp_32f(const float *a, float *c, int n)
+void p_exp_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_inv.c
+++ b/src/math/p_inv.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_inv_32f(float *a, float *c, int n)
+void p_inv_f32(float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_invcbrt.c
+++ b/src/math/p_invcbrt.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_invcbrt_32f(float *a, float *c, int n)
+void p_invcbrt_f32(float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_invsqrt.c
+++ b/src/math/p_invsqrt.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_invsqrt_32f(float *a, float *c, int n)
+void p_invsqrt_f32(float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_ln.c
+++ b/src/math/p_ln.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_ln_32f(float *a, float *c, int n)
+void p_ln_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_log10.c
+++ b/src/math/p_log10.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_log10_32f(float *a, float *c, int n)
+void p_log10_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_mac.c
+++ b/src/math/p_mac.c
@@ -16,7 +16,7 @@
  *
  */
 
-void p_mac_32f(float *a, float *b, float *c, int n)
+void p_mac_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_max.c
+++ b/src/math/p_max.c
@@ -14,7 +14,7 @@
  *
  */
 
-void p_max_32f(float *a, float *c, int *index, int n)
+void p_max_f32(float *a, float *c, int *index, int n)
 {
     int i;
     *c = 3.40282346638528860e+38;

--- a/src/math/p_mean.c
+++ b/src/math/p_mean.c
@@ -13,7 +13,7 @@
  * @return      None
  *
  */
-void p_mean_32f(float *a, float *c, int n)
+void p_mean_f32(float *a, float *c, int n)
 {
 
     int i = 0;

--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -14,4 +14,4 @@
  *
  */
 
-void p_median_32f(float *a, float *c, int n) {}
+void p_median_f32(float *a, float *c, int n) {}

--- a/src/math/p_min.c
+++ b/src/math/p_min.c
@@ -14,7 +14,7 @@
  * @return      None
  *
  */
-void p_min_32f(float *a, float *c, int *index, int n)
+void p_min_f32(float *a, float *c, int *index, int n)
 {
 
     int i;

--- a/src/math/p_mode.c
+++ b/src/math/p_mode.c
@@ -14,4 +14,4 @@
  *
  */
 
-void p_mode_32f(float *a, float *c, int n) {}
+void p_mode_f32(float *a, float *c, int n) {}

--- a/src/math/p_mul.c
+++ b/src/math/p_mul.c
@@ -14,7 +14,7 @@
  *
  */
 
-void p_mul_32f(float *a, float *b, float *c, int n)
+void p_mul_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_pow.c
+++ b/src/math/p_pow.c
@@ -16,7 +16,7 @@
  *
  */
 #include <math.h>
-void p_pow_32f(float *a, float *b, float *c, int n)
+void p_pow_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_sincos.c
+++ b/src/math/p_sincos.c
@@ -15,4 +15,4 @@
  *
  */
 #include <math.h>
-void p_sincos_32f(const float *a, float *c, float *z) {}
+void p_sincos_f32(const float *a, float *c, float *z) {}

--- a/src/math/p_sinh.c
+++ b/src/math/p_sinh.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_sinh_32f(float *a, float *c, int n)
+void p_sinh_f32(float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_sort.c
+++ b/src/math/p_sort.c
@@ -13,6 +13,6 @@
  * @return      None
  *
  */
-void p_sort_32f(float *a, float *c, int n) {}
+void p_sort_f32(float *a, float *c, int n) {}
 
 void p_sort_u32(int *a, int *c, int n) {}

--- a/src/math/p_sqrt.c
+++ b/src/math/p_sqrt.c
@@ -14,7 +14,7 @@
  *
  */
 #include <math.h>
-void p_sqrt_32f(float *a, float *c, int n)
+void p_sqrt_f32(float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_sub.c
+++ b/src/math/p_sub.c
@@ -16,7 +16,7 @@
  *
  */
 
-void p_sub_32f(float *a, float *b, float *c, int n)
+void p_sub_f32(float *a, float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_sum.c
+++ b/src/math/p_sum.c
@@ -14,7 +14,7 @@
  *
  */
 
-void p_sum_32f(float *a, float *c, int n)
+void p_sum_f32(float *a, float *c, int n)
 {
 
     int i = 0;

--- a/src/math/p_sumsq.c
+++ b/src/math/p_sumsq.c
@@ -14,7 +14,7 @@
  *
  */
 
-void p_sumsq_32f(float *a, float *c, int n)
+void p_sumsq_f32(float *a, float *c, int n)
 {
 
     int i = 0;

--- a/src/math/p_tan.c
+++ b/src/math/p_tan.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_tan_32f(float *a, float *c, int n)
+void p_tan_f32(float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_tanh.c
+++ b/src/math/p_tanh.c
@@ -15,7 +15,7 @@
  *
  */
 #include <math.h>
-void p_tanh_32f(float *a, float *c, int n)
+void p_tanh_f32(float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {


### PR DESCRIPTION
This fixes linker error of 'undefined reference to `p_..._f32`'
in math module.
> #8