### PR TITLE
math: p_popcount: Implement function logic

### DIFF
--- a/src/math/p_popcount.c
+++ b/src/math/p_popcount.c
@@ -15,5 +15,20 @@
  */
 void p_popcount_u32(unsigned int *a, unsigned int *c, int n)
 {
-    /* Implement me */
+    static const unsigned int A[] = {0x55555555, 0x33333333,
+                                     0x0f0f0f0f, 0x01010101};
+    unsigned int *pa, *pc;
+    unsigned int tmp;
+    int i;
+
+    pa = a;
+    pc = c;
+
+    for (i = 0; i < n; i++) {
+        tmp = *pa - ((*pa >> 1) & A[0]);
+        tmp = (tmp & A[1]) + ((tmp >> 2) & A[1]);
+        *pc = ((tmp + (tmp >> 4)) & A[2]) * A[3] >> 24;
+        pc++;
+        pa++;
+    }
 }


### PR DESCRIPTION
Using classic sideways addition method.
It counts all bits in just 12 operations for 32 bit integer.

This commit resolves #28.

Signed-off-by: Mateusz Kacprzak <mateusz.kacprzak@yandex.ru>