### PR TITLE
math: p_sincos: Add function implementation

### DIFF
--- a/src/math/p_sincos.c
+++ b/src/math/p_sincos.c
@@ -22,8 +22,8 @@
  * @return      None
  *
  */
-#include <math.h>
 void p_sincos_f32(float *a, float *c, float *z, int n, int p, p_team_t team)
 {
-    /* TODO: Implement me */
+    p_sin_f32(a, c, n, 0, team);
+    p_cos_f32(a, z, n, 0, team);
 }


### PR DESCRIPTION
Naive implementation using already defined API functions.
Removed math.h include since used funcs reside in pal_math.h
included with pal.h
Resolves #32.

Signed-off-by: Mateusz Kacprzak <mateusz.kacprzak@yandex.ru>