### PR TITLE
doc: p_sad: Change result type from scalar to vector

### DIFF
--- a/src/image/p_sad16x16.c
+++ b/src/image/p_sad16x16.c
@@ -8,7 +8,7 @@
  *
  * @param m     Pointer to an 16x16 pixel array within the image.
  *
- * @param r     Result scalar
+ * @param r     Result vector
  *
  * @param rows  Number of rows in input image
  *

--- a/src/image/p_sad8x8.c
+++ b/src/image/p_sad8x8.c
@@ -8,7 +8,7 @@
  *
  * @param m     Pointer to an 8x8 pixel array within the image.
  *
- * @param r     Result scalar
+ * @param r     Result vector
  *
  * @param rows  Number of rows in input image
  *


### PR DESCRIPTION
Eg. running p_sad8x8 on image of size 8x10 will produce a result vector of size 3.