### PR TITLE
math: p_mode: Add p_mode function implementation

### DIFF
--- a/src/math/p_mode.c
+++ b/src/math/p_mode.c
@@ -18,6 +18,31 @@
  *
  */
 
-void p_mode_f32(float *a, float *c, int n, int p, p_team_t team) 
+void p_mode_f32(float *a, float *c, int n, int p, p_team_t team)
 {
+    unsigned int occurrence_count = 0;
+    unsigned int max_occurrence_count = 0;
+    unsigned int i = 1;
+    float mode_value = 0.0f;
+    float *sorted_a = (float*) p_malloc(team, sizeof(float) * n);
+    p_sort_f32(a, sorted_a, n, p, team);
+
+    for (; i < n; ++i) {
+        ++occurrence_count;
+        if (sorted_a[i] != sorted_a[i - 1]) {
+            if (occurrence_count > max_occurrence_count) {
+                max_occurrence_count = occurrence_count;
+                mode_value = sorted_a[i - 1];
+            }
+            occurrence_count = 0;
+        }
+    }
+    if (occurrence_count > max_occurrence_count) {
+        max_occurrence_count = occurrence_count;
+        mode_value = sorted_a[n - 1];
+    }
+
+    *c = mode_value;
+
+    p_free(sorted_a);
 }


### PR DESCRIPTION
It is part of parallella/pal#41

In order to test this code I implemented very basic versions of p_sort, p_memcpy and p_malloc using the C standard library. I can pull them as well if needed.

Signed-off-by: Wesley Ceraso Prudencio <wesleyceraso@gmail.com>