### PR TITLE
math: p_mode: Add p_mode function implementation and example

### DIFF
--- a/examples/base/Makefile.am
+++ b/examples/base/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS = foreign
 
 LDADD = $(top_builddir)/src/libpal.la
 
-noinst_PROGRAMS = hello_task simple_example sine_task sort_task median_task
+noinst_PROGRAMS = hello_task simple_example sine_task sort_task median_task mode_task
 
 hello_task_SOURCES = hello_task.c
 simple_example_SOURCES = simple_example.c
@@ -12,3 +12,5 @@ sine_task_SOURCES = sine_task.c
 sort_task_SOURCES = sort_task.c
 
 median_task_SOURCES = median_task.c
+
+mode_task_SOURCES = mode_task.c

--- a/examples/base/mode_task.c
+++ b/examples/base/mode_task.c
@@ -1,0 +1,46 @@
+#include "pal.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+    p_team_t team0;
+
+    unsigned int size_a = 10;
+    unsigned int size_b = 15;
+    unsigned int size_c = 7;
+
+    float a[] = {1, 3, 3, 3, 4, 4, 6, 6, 6, 9};
+    float b[] = {3.f, 7.f, 5.f, 1.3f, 2.0f, 2.3f, 3.9f, 2.3f, 4.0f, 2.3f, 1.4f, 1.2f, 5.6f, 2.3f, 2.9f};
+    float c[] = {19, 8, 29, 35, 19, 28, 15};
+    
+    float m_a = 0.0f;
+    float m_b = 0.0f;
+    float m_c = 0.0f;
+
+    unsigned int i = 0;
+
+    p_mode_f32(a, &m_a, size_a, 0, team0);
+    p_mode_f32(b, &m_b, size_b, 0, team0);
+    p_mode_f32(c, &m_c, size_c, 0, team0);
+
+    printf("[");
+    for (i = 0; i < size_a; ++i) {
+        printf("%2.5f ", a[i]);
+    }
+    printf("]\nMode: %2.5f\n", m_a);
+
+    printf("[");
+    for (i = 0; i < size_b; ++i) {
+        printf("%2.5f ", b[i]);
+    }
+    printf("]\nMode: %2.5f\n", m_b);
+
+    printf("[");
+    for (i = 0; i < size_c; ++i) {
+        printf("%2.5f ", c[i]);
+    }
+    printf("]\nMode: %2.5f\n", m_c);
+
+    return 0;
+}

--- a/src/math/p_mode.c
+++ b/src/math/p_mode.c
@@ -18,6 +18,31 @@
  *
  */
 
-void p_mode_f32(float *a, float *c, int n, int p, p_team_t team) 
+void p_mode_f32(float *a, float *c, int n, int p, p_team_t team)
 {
+    unsigned int occurrence_count = 0;
+    unsigned int max_occurrence_count = 0;
+    unsigned int i = 1;
+    float mode_value = 0.0f;
+    float *sorted_a = (float*) p_malloc(team, sizeof(float) * n);
+    p_sort_f32(a, sorted_a, n, p, team);
+
+    for (; i < n; ++i) {
+        ++occurrence_count;
+        if (sorted_a[i] != sorted_a[i - 1]) {
+            if (occurrence_count > max_occurrence_count) {
+                max_occurrence_count = occurrence_count;
+                mode_value = sorted_a[i - 1];
+            }
+            occurrence_count = 0;
+        }
+    }
+    if (occurrence_count > max_occurrence_count) {
+        max_occurrence_count = occurrence_count;
+        mode_value = sorted_a[n - 1];
+    }
+
+    *c = mode_value;
+
+    p_free(sorted_a);
 }


### PR DESCRIPTION
In order to test this code I implemented very basic versions of p_sort, p_memcpy and p_malloc using the C standard library. I can pull them as well if needed.

Closes: parallella/pal#51
Is part of: parallella/pal#41

Signed-off-by: Wesley Ceraso Prudencio <wesleyceraso@gmail.com>