### PR TITLE
added p_sqrt_f32 using magic constant

### DIFF
--- a/src/math/p_sqrt.c
+++ b/src/math/p_sqrt.c
@@ -4,6 +4,16 @@
  *
  * Calculates the square root of the input vector 'a'.
  *
+ * Author: Matt Thompson <mthompson@hexwave.com>
+ * Date: June 2, 2015
+ *
+ * This uses a method to approximate sqrt which only applies to IEEE 754 floating point numbers,
+ * described in [1]. The optimized magic constant is from Chris Lomont[2]
+ *
+ * References:
+ * 1: http://en.wikipedia.org/wiki/Fast_inverse_square_root
+ * 2: http://www.lomont.org/Math/Papers/2003/InvSqrt.pdf
+ *
  * @param a     Pointer to input vector
  *
  * @param c     Pointer to output vector
@@ -18,11 +28,29 @@
  *
  */
 #include <math.h>
+
 void p_sqrt_f32(float *a, float *c, int n, int p, p_team_t team)
 {
-
+    
     int i;
     for (i = 0; i < n; i++) {
-        *(c + i) = sqrtf(*(a + i));
+        float *pa = (a+i);
+        float *pc = (c+i);
+        float x;
+        int32_t j;
+        float xhalf = 0.5f*(*pa);
+ 
+        j = *(int32_t*)(pa);
+        j = 0x5f375a86 - (j>>1);
+        x = *(float*)&j;
+
+        // Newton steps, repeating this increases accuracy
+        x = x*(1.5f - xhalf*x*x);
+        x = x*(1.5f - xhalf*x*x);
+
+        // x contains the inverse sqrt
+
+        // Multiply the inverse sqrt by the input to get the sqrt
+        *pc = *pa * x;
     }
 }


### PR DESCRIPTION
This is based on the inverse function described here http://en.wikipedia.org/wiki/Fast_inverse_square_root

Tests pass on x86_64 with two newton passes, but this is highly specific to IEEE 754 binary format.
