### PR TITLE
Branchless absolute value toggling sign bit

### DIFF
--- a/src/math/p_abs.c
+++ b/src/math/p_abs.c
@@ -20,13 +20,12 @@
 #include <math.h>
 void p_abs_f32(float *a, float *c, int n, int p, p_team_t team)
 {
-
+    uint32_t tmp;
     int i;
+
     for (i = 0; i < n; i++) {
-        if (*(a + i) < 0) {
-            *(c + i) = -*(a + i);
-        } else {
-            *(c + i) = *(a + i);
-        }
+        tmp = *(uint32_t*)(a + i);
+        tmp &= 0x7FFFFFFF;
+        *(c + i) = *(float*)&tmp;
     }
 }


### PR DESCRIPTION
IEEE 754 floats most significant bit is the sign bit.  Because bitwise operators aren't allowed on floating point values, cast to 32 bit int, clear the sign bit, and assign to the destination vector.