### PR TITLE
math: p_median: Improves p_median function implementation and example

### DIFF
--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -222,7 +222,7 @@ void p_sumsq_f32(float *a, float *c, int n, int p, p_team_t team);
 void p_mean_f32(float *a, float *c, int n, int p, p_team_t team);
 
 /*middle value: c = median ( a[n-1:0] ) */
-void p_median_f32(float *a, float *c, int n, int p, p_team_t team);
+void p_median_f32(float *a, float *c, size_t n, int p, p_team_t team)
 
 /*most common number: c = mode ( a[n-1:0] ) */
 void p_mode_f32(float *a, float *c, int n, int p, p_team_t team);

--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -25,7 +25,7 @@ void p_median_f32(float *a, float *c, int n, int p, p_team_t team)
     p_sort_f32(a, sort, n, p, team);
 
     if(n%2)
-        *c=a[n>>1];
+        *c=sort[n>>1];
     else
-        *c=(a[n>>1] + a[(n-1)>>1])*.5;
+        *c=(sort[n>>1] + sort[(n>>1) - 1])*.5;
 }

--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -1,5 +1,30 @@
 #include <pal.h>
 
+static void swap(float *lhs, float *rhs)
+{
+    float tmp = *lhs;
+    *lhs = *rhs;
+    *rhs = tmp;
+}
+
+static unsigned int median_partition(float *a, unsigned int left, unsigned int right, unsigned int pivot_index)
+{
+    unsigned int store_index = left;
+    unsigned int i = left;
+
+    float pivot = a[pivot_index];
+    swap(&a[pivot_index], &a[right]);
+
+    for (; i < right; ++i) {
+        if (a[i] < pivot)
+            swap(&a[i], &a[store_index++]);
+    }
+
+    swap(&a[store_index], &a[right]);
+
+    return store_index;
+}
+
 /**
  *
  * Calculates the median value of input vector 'a'.
@@ -18,14 +43,31 @@
  *
  */
 
-void p_median_f32(float *a, float *c, int n, int p, p_team_t team)
+void p_median_f32(float *a, float *c, size_t n, int p, p_team_t team)
 {
-    float sort[n];
+    unsigned int left = 0;
+    unsigned int median_index = (n - 1) >> 1;
+    float median_value = 0.0f;
+    float search_a[n];
+    
+    p_memcpy(search_a, a, sizeof(float) * n, P_FLAG_DEFAULT);
+    
+    for (; median_index <= (n >> 1); ++median_index) {
+        unsigned int right = n - 1;
+        unsigned int pivot_index = 0;
+        
+        do {
+            pivot_index = median_partition(search_a, left, right, (left + right) >> 1);
 
-    p_sort_f32(a, sort, n, p, team);
+            if (pivot_index > median_index) {
+                right = pivot_index - 1;
+            } else {
+                left = pivot_index + 1;
+            }
+        } while (pivot_index != median_index);
 
-    if(n%2)
-        *c=sort[n>>1];
-    else
-        *c=(sort[n>>1] + sort[(n>>1) - 1])*.5;
+        median_value += search_a[pivot_index];
+    }
+    
+    *c = (n % 2 ? median_value : median_value * 0.5);
 }


### PR DESCRIPTION
Closes: parallella/pal#57
Is part of: parallella/pal#41

Although there were no implementation of p_median when I started coding, the current is O(n log n) because it sorts the whole array, and uses the stack instead of the heap (stack generally has little space available). My solution have a expected time of O(n) (uses QuickSelect) and uses heap.

Signed-off-by: Wesley Ceraso Prudencio <wesleyceraso@gmail.com>