### PR TITLE
Implement a faster inverse square root method

### DIFF
--- a/src/math/p_invsqrt.c
+++ b/src/math/p_invsqrt.c
@@ -4,6 +4,11 @@
  *
  * Calculates the inverse square root of the input vector 'a'.
  *
+ * This function uses a method of computing the inverse square root
+ * made popular by the Quake 3 source code release. Chris Lomont has
+ * provided an exhaustive analysis here: 
+ * http://www.lomont.org/Math/Papers/2003/InvSqrt.pdf
+ *
  * @param a     Pointer to input vector
  *
  * @param c     Pointer to output vector
@@ -20,8 +25,29 @@
 #include <math.h>
 void p_invsqrt_f32(float *a, float *c, int n, int p, p_team_t team)
 {
+    // This union allows us to type-pun between integers and floats
+    // with fewer strict aliasing concerns than the pointer casts
+    // used in the original source.
+    union
+    {
+        int32_t i;
+        float f;
+    } u;
+
     int i;
     for (i = 0; i < n; i++) {
-        *(c + i) = 1.0f / sqrtf(*(a + i));
+        float x = *(a + i);
+        float x2 = x * 0.5f;
+
+        // Use some bit hacks to get a decent first approximation
+        u.f = x;
+        u.i = 0x5f375a86 - (u.i >> 1);
+        x = u.f;
+
+        // Perform a couple steps of Newton's method to refine our guess
+        x = x * (1.5f - (x2 * x * x));
+        x = x * (1.5f - (x2 * x * x));
+
+        *(c + i) = x;
     }
 }

--- a/src/math/p_ln.c
+++ b/src/math/p_ln.c
@@ -17,12 +17,31 @@
  * @return      None
  *
  */
-#include <math.h>
+
 void p_ln_f32(float *a, float *c, int n, int p, p_team_t team)
 {
-
     int i;
     for (i = 0; i < n; i++) {
-        *(c + i) = logf(*(a + i));
+        union
+        {
+            float f;
+            uint32_t i;
+        } u = { *(a + i) };
+
+        // Calculate the exponent (which is the floor of the logarithm) minus one
+        int e = ((u.i >> 23) & 0xff) - 0x80;
+
+        // Mask off the exponent, leaving just the mantissa
+        u.i = (u.i & 0x7fffff) + 0x3f800000;
+
+        // Interpolate using a cubic minimax polynomial derived with
+        // the Remez exchange algorithm. Coefficients courtesy of Alex Kan.
+        // This approximates 1 + log2 of the mantissa.
+        float r = ((0.15824870f * u.f - 1.05187502f) * u.f + 3.04788415f) * u.f - 1.15360271f;
+
+        // The log2 of the complete value is then the sum
+        // of the previous quantities (the 1's cancel), and
+        // we find the natural log by scaling by log2(e).
+        *(c + i) = (e + r) * 0.69314718f;
     }
 }


### PR DESCRIPTION
This function passes the existing inverse square root unit test, but I have not benchmarked it or verified it against a larger test data set.