### PR TITLE
pal_math.h: Fix warnings about redefined constants

### DIFF
--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -6,7 +6,7 @@
 
 /* Standard math constants. Seems to be in every math.h */
 #if !(defined __USE_BSD || defined __USE_XOPEN || defined __USE_GNU || \
-      defined _NEWLIB_VERSION)
+      defined _NEWLIB_VERSION || defined __USE_MISC)
 #define M_E 2.71828182845904523540        /* e */
 #define M_LOG2E 1.44269504088896340740    /* log 2e */
 #define M_LOG10E 0.43429448190325182765   /* log 10e */


### PR DESCRIPTION
A fragment of the warnings I get:

```
In file included from ../../include/pal.h:4:0,
                 from mode_task.c:1:
../../include/pal_math.h:10:0: warning: "M_E" redefined
 #define M_E 2.71828182845904523540        /* e */
 ^
In file included from ../../include/pal_math.h:3:0,
                 from ../../include/pal.h:4,
                 from mode_task.c:1:
/usr/include/math.h:367:0: note: this is the location of the previous definition
 # define M_E  2.7182818284590452354 /* e */
 ^
In file included from ../../include/pal.h:4:0,
                 from mode_task.c:1:
../../include/pal_math.h:11:0: warning: "M_LOG2E" redefined
 #define M_LOG2E 1.44269504088896340740    /* log 2e */
 ^
In file included from ../../include/pal_math.h:3:0,
                 from ../../include/pal.h:4,
                 from mode_task.c:1:
/usr/include/math.h:368:0: note: this is the location of the previous definition
 # define M_LOG2E 1.4426950408889634074 /* log_2 e */
 ^
```