### PR TITLE
base absdiff() off of recent changes to abs()

### DIFF
--- a/src/math/p_absdiff.c
+++ b/src/math/p_absdiff.c
@@ -26,6 +26,8 @@ void p_absdiff_f32(float *a, float *b, float *c, int n, int p, p_team_t team)
     int i;
     for (i = 0; i < n; i++) {
         float v = *(a + i) - *(b + i);
-        *(c + i) = (1 - ((v < 0) << 1)) * v;
+        uint32_t tmp = *(uint32_t*) &v;
+        tmp &= 0x7FFFFFFF;
+        *(c + i) = *(float*) &tmp;
     }
 }


### PR DESCRIPTION
Hi, the other guy (@jeff-ayars) got to abs() before me :-)  There was a comment about updating absdiff() to reflect the new definition of abs() - that is what I have done here.

(g'day!)

PS: I wasn't thinking when I made a pull request off of my master, now this includes a cleanup to p_median() also.