### PR TITLE
Improve p_median performance and add p_find_kth_f32

### DIFF
--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -147,6 +147,9 @@ void p_div_f32(const float *a, const float *b, float *c,
 /*exponential: c = exp ( a ) */
 void p_exp_f32(const float *a, float *c, int n, int p, p_team_t team);
 
+/*find kth: c = sort(a)[k] */
+void p_find_kth_f32(float *a, float *c, int k, int n, int p, p_team_t team);
+
 /*inverse: c = 1 / ( a ) */
 void p_inv_f32(const float *a, float *c, int n, int p, p_team_t team);
 

--- a/src/math/Makefile.am
+++ b/src/math/Makefile.am
@@ -21,6 +21,7 @@ libpal_math_la_SOURCES = \
     p_div.c \
     p_dot.c \
     p_exp.c \
+    p_find_kth_f32.c \
     p_ftoi.c \
     p_inv.c \
     p_invcbrt.c \

--- a/src/math/p_find_kth_f32.c
+++ b/src/math/p_find_kth_f32.c
@@ -1,0 +1,78 @@
+#include <pal.h>
+
+/**
+ *
+ * Finds the k-th value of input vector 'a' as if it were sorted.
+ * Note that this will touch the input vector and swap elements.
+ * Make a copy before calling if you want to keep it unchanged.
+ * The time complexity is linear over the vector size. O(n).
+ *
+ * @param v     Pointer to input vector
+ *
+ * @param e     Pointer to output scalar
+ *
+ * @param n     Size of 'a' vector.
+ *
+ * @param k     Index of the element to find.
+ *
+ * @param p     Number of processor to use (task parallelism)
+ *
+ * @param team  Team to work with
+ *
+ * @return      None
+ *
+ */
+
+#define swap(a, b) {float c = (a); (a) = (b); (b) = c;}
+
+void p_find_kth_f32(float* v, float* e, int n, int k, int p, p_team_t team) {
+    if (n == 1 && k == 0) {
+        *e = v[0];
+        return;
+    }
+
+    int m = (n + 4)/5;
+    float pivot;
+    {
+        float meds[m];
+        for (int i = 0; i < m; i++) {
+            if (5*i + 4 < n) {
+                float* w = v + 5*i;
+                for (int j0 = 0; j0 < 3; j0++) {
+                    int jmin = j0;
+                    for (int j = j0+1; j < 5; j++)
+                        if (w[j] < w[jmin])
+                            jmin = j;
+                    swap(w[j0], w[jmin]);
+                }
+                meds[i] = w[2];
+            } else {
+                meds[i] = v[5*i];
+            }
+        }
+
+        p_find_kth_f32(meds, &pivot, m, m/2, p, team);
+    }
+
+    for (int i = 0; i < n; i++) {
+        if (v[i] == pivot) {
+            swap(v[i], v[n-1]);
+            break;
+        }
+    }
+
+    int store = 0;
+    for (int i = 0; i < n-1; i++)
+        if (v[i] < pivot)
+            swap(v[i], v[store++]);
+
+    swap(v[store], v[n-1]);
+
+    if (store == k)
+        *e = pivot;
+    else if (store > k)
+        p_find_kth_f32(v, e, store, k, p, team);
+    else
+        p_find_kth_f32(v+store+1, e, n-store-1, k-store-1, p, team);
+}
+

--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -20,12 +20,18 @@
 
 void p_median_f32(const float *a, float *c, int n, int p, p_team_t team)
 {
-    float sort[n];
+    float copy[n];
+    int i;
+    for (i = 0; i < n; ++i)
+        copy[i] = a[i];
 
-    p_sort_f32(a, sort, n, p, team);
-
-    if(n%2)
-        *c=a[n>>1];
-    else
-        *c=(a[n>>1] + a[(n-1)>>1])*.5;
+    if (n & 1) {
+        p_find_kth_f32(copy, c, n, n/2, p, team);
+    } else {
+        float m1, m2;
+        p_find_kth_f32(copy, &m1, n, n/2, p, team);
+        p_find_kth_f32(copy, &m2, n, n/2+1, p, team);
+        *c = (m1 + m2) * .5;
+    }
 }
+

--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -26,11 +26,11 @@ void p_median_f32(const float *a, float *c, int n, int p, p_team_t team)
         copy[i] = a[i];
 
     if (n & 1) {
-        p_find_kth_f32(copy, c, n, n/2, p, team);
+        p_find_kth_f32(copy, c, n, n >> 1, p, team);
     } else {
         float m1, m2;
-        p_find_kth_f32(copy, &m1, n, n/2, p, team);
-        p_find_kth_f32(copy, &m2, n, n/2+1, p, team);
+        p_find_kth_f32(copy, &m1, n, n >> 1, p, team);
+        p_find_kth_f32(copy, &m2, n, (n>>1)+1, p, team);
         *c = (m1 + m2) * .5;
     }
 }


### PR DESCRIPTION
Previously it did a full sort of the input vector taking `O(n log n)`. Now it will use the select/median of medians algorithm to find only the element it cares about. Now takes `O(n)`, a linear time. This improves performance when dealing with large vectors.