### PR TITLE
Branchless version of function

### DIFF
--- a/src/math/p_ftoi.c
+++ b/src/math/p_ftoi.c
@@ -1,5 +1,6 @@
 #include <pal.h>
 
+#define ZERO_POINT_FIVE 0x3F000000 // IEEE-754 32 bit float value for 0.5f 
 /**
  *
  * Converts the floating point values in 'a' to signed integer values.
@@ -20,7 +21,13 @@
 
 void p_ftoi(const float *a, int *c, int n, int p, p_team_t team)
 {
-  for(int i = 0; i<n; i++) {
-    *(c+i) = (*(a+i)>=0) ? (int) (*(a+i)+0.5) : (int) (*(a+i)-0.5);
+  uint32_t tmp;
+  float rounding_value;
+
+  for(i = 0; i<n; i++)
+  {
+    tmp = ((*(uint32_t*)(a + i)) & 0x80000000) | ZERO_POINT_FIVE;
+    rounding_value = *((float*)&tmp);
+    *(c+i) = (int) (*(a+i) + rounding_value);
   }
 }


### PR DESCRIPTION
Get the sign bit from the input float and set that sign bit on 0.5f rounding value so we can always add the rounding value to the input instead of checking the sign and branching to add or subtract 0.5f.  Used #define for the magic number to help be more self documenting.  Don't know if that fits the style or not, easy to take it out.