### PR TITLE
math:p_stddev Add function to Makefile.am

### DIFF
--- a/src/math/Makefile.am
+++ b/src/math/Makefile.am
@@ -43,6 +43,7 @@ libpal_math_la_SOURCES = \
     p_sinh.c \
     p_sort.c \
     p_sqrt.c \
+    p_stddev.c \
     p_sub.c \
     p_sum.c \
     p_sumsq.c \


### PR DESCRIPTION
Problem:
File p_stddev.c is not present in Makefile.am

Solution:
Adding file to sources in Makefile.am