### PR TITLE
Remove team parameter from lower level API

### DIFF
--- a/benchmark/example.c
+++ b/benchmark/example.c
@@ -7,18 +7,14 @@ void bench_p_add(const struct p_benchmark_specification* spec)
 	p_add_f32(spec->mem.input_float_first,
 		spec->mem.input_float_second,
 		spec->mem.output_float,
-		spec->current_size,
-		spec->p,
-		spec->team);
+		spec->current_size);
 }
 
 void bench_p_sqrt(const struct p_benchmark_specification* spec)
 {
 	p_sqrt_f32(spec->mem.input_float_first,
 		spec->mem.output_float,
-		spec->current_size,
-		spec->p,
-		spec->team);
+		spec->current_size);
 }
 
 const struct p_benchmark_item benchmark_items[] = {

--- a/benchmark/wrapper.h
+++ b/benchmark/wrapper.h
@@ -70,8 +70,6 @@ struct p_benchmark_specification
 {
 	struct p_benchmark_raw_memory mem;
 	size_t current_size;
-	int p;
-	p_team_t team;
 };
 
 struct p_benchmark_item

--- a/examples/base/median_task.c
+++ b/examples/base/median_task.c
@@ -13,11 +13,10 @@ int main()
 
     int match;
     float median;
-	p_team_t team;
 
 	puts("Running first test");
 
-    p_median_f32(a, &median, a_n, 1, team);
+    p_median_f32(a, &median, a_n);
 
     if(median==a_expected_median)
         match=1;
@@ -29,7 +28,7 @@ int main()
 
 	puts("\nRunning second test");
 
-    p_median_f32(b, &median, b_n, 1, team);
+    p_median_f32(b, &median, b_n);
 
     if(median==b_expected_median)
         match=1;

--- a/examples/base/mode_task.c
+++ b/examples/base/mode_task.c
@@ -4,8 +4,6 @@
 
 int main(int argc, char *argv[])
 {
-    p_team_t team0;
-
     unsigned int size_a = 10;
     unsigned int size_b = 15;
     unsigned int size_c = 7;
@@ -20,9 +18,9 @@ int main(int argc, char *argv[])
 
     unsigned int i = 0;
 
-    p_mode_f32(a, &m_a, size_a, 0, team0);
-    p_mode_f32(b, &m_b, size_b, 0, team0);
-    p_mode_f32(c, &m_c, size_c, 0, team0);
+    p_mode_f32(a, &m_a, size_a);
+    p_mode_f32(b, &m_b, size_b);
+    p_mode_f32(c, &m_c, size_c);
 
     printf("[");
     for (i = 0; i < size_a; ++i) {

--- a/examples/base/sine_task.c
+++ b/examples/base/sine_task.c
@@ -6,9 +6,8 @@ int main()
     int size = 1;
     float a[3] = { 0.0, 0.5, 1.0 };
     float b[3];
-    p_team_t team;
     printf("Running p_sin_32f()\n");
-    p_sin_f32(a, b, size,1,team);
-    
+    p_sin_f32(a, b, size);
+
     return 0;
 }

--- a/examples/base/sort_task.c
+++ b/examples/base/sort_task.c
@@ -3,7 +3,6 @@
 
 int main()
 {
-	p_team_t team;
 #define FSIZE 30
 	int fsize = FSIZE;
 	float fin[FSIZE] = {
@@ -39,7 +38,7 @@ int main()
 	int i;
 
 	printf("Running p_sort_f32()\n");
-	p_sort_f32(fin, fout, fsize, 1, team);
+	p_sort_f32(fin, fout, fsize);
 	printf("Results:\n");
 	sorted = 1;
 	ulast = fout[0];
@@ -54,7 +53,7 @@ int main()
 	printf("\n");
 
 	printf("Running p_sort_u32()\n");
-	p_sort_u32(uin, uout, usize, 1, team);
+	p_sort_u32(uin, uout, usize);
 	printf("Results:\n");
 	sorted = 1;
 	ulast = uout[0];

--- a/examples/image/filters.c
+++ b/examples/image/filters.c
@@ -31,8 +31,6 @@ void float_to_ubyte(unsigned char *dest, float *src, int size)
 
 int main(int argc, char *argv[])
 {
-    p_team_t team;
-  
     float *data;
     float *dest;
     unsigned char *data_ub; /* ubyte data */
@@ -68,7 +66,7 @@ int main(int argc, char *argv[])
     
     /* gaussian */
     {
-        p_gauss3x3_f32(data, dest, h, w, 1, team);   
+        p_gauss3x3_f32(data, dest, h, w);
         float_to_ubyte(data_ub, dest, size);
         stbi_write_tga("../dataset/lena_gaussian.tga", w-2, h-2, 1, data_ub);
     }
@@ -76,7 +74,7 @@ int main(int argc, char *argv[])
     /* harris */
     {
         float *tmp = malloc(size * 3 * sizeof(float));
-        p_harris3x3_f32(data, dest, tmp, h, w, 1, team);
+        p_harris3x3_f32(data, dest, tmp, h, w);
 	free(tmp);
         float_to_ubyte(data_ub, dest, size);
         stbi_write_tga("../dataset/lena_harris.tga", w-4, h-4, 1, data_ub);
@@ -84,21 +82,21 @@ int main(int argc, char *argv[])
     
     /* sobel */
     {
-        p_sobel3x3_f32(data, dest, h, w, 1, team);   
+        p_sobel3x3_f32(data, dest, h, w);   
         float_to_ubyte(data_ub, dest, size);
         stbi_write_tga("../dataset/lena_sobel.tga", w, h, 1, data_ub);
     }
     
     /* box */
     {
-        p_box3x3_f32(data, dest, h, w, 1, team);   
+        p_box3x3_f32(data, dest, h, w);   
         float_to_ubyte(data_ub, dest, size);
         stbi_write_tga("../dataset/lena_box.tga", w-2, h-2, 1, data_ub);
     }
     
     /* median */
     {
-        p_median3x3_f32(data, dest, h, w, 1, team);   
+        p_median3x3_f32(data, dest, h, w);   
         float_to_ubyte(data_ub, dest, size);
         stbi_write_tga("../dataset/lena_median.tga", w-2, h-2, 1, data_ub);
     }

--- a/examples/image/harris.c
+++ b/examples/image/harris.c
@@ -11,7 +11,6 @@
 
 int main(int argc, char *argv[])
 {
-    p_team_t team;
     int i, j;
     
     float src[W*W] = {
@@ -32,7 +31,7 @@ int main(int argc, char *argv[])
     float dest[W4*W4];
     float tmp[W2*W2*3];
  
-    p_harris3x3_f32(src, dest, tmp, W, W, 1, team);
+    p_harris3x3_f32(src, dest, tmp, W, W);
     
     /* src */
     for (i = 0; i < W; i++) {

--- a/include/pal_dsp.h
+++ b/include/pal_dsp.h
@@ -15,34 +15,28 @@
  */
 
 /*auto correlation: r[j] = sum ( x[j+k] * x[k] ), k=0..(n-j-1) */
-void p_acorr_f32(const float *x, float *r, int nx, int nr,
-                 int p, p_team_t team);
+void p_acorr_f32(const float *x, float *r, int nx, int nr);
 
 /*convolution: r[j] = sum ( h[k] * x[j-k), k=0..(nh-1) */
-void p_conv_f32(const float *x, const float *h, float *r, int nr, int nh,
-                int p, p_team_t team);
+void p_conv_f32(const float *x, const float *h, float *r, int nr, int nh);
 
 /*cross correlation: r[j] = sum ( x[j+k] * y[k]), k=0..(nx+ny-1) */
 /* NOTE: current implementation requires nx >= ny */
-void p_xcorr_f32(const float *x, const float *y, float *r, int nx, int ny,
-                 int p, p_team_t team);
+void p_xcorr_f32(const float *x, const float *y, float *r, int nx, int ny);
 
 /*FIR filter direct form: r[j] = sum ( h[k] * x [j-k]), k=0..(nh-1) */
-void p_fir_f32(const float *x, const float *h, float *r, int nx, int nh,
-               int p, p_team_t team);
+void p_fir_f32(const float *x, const float *h, float *r, int nx, int nh);
 
 /*FIR filter with decimation: r[j] = sum ( h[k] * x [j*D-k]), k=0..(nh-1) */
 void p_firdec_f32(const float *x, const float *h, float *r,
-                  int nx, int nh, int df, int p, p_team_t team);
+                  int nx, int nh, int df);
 
 /*FIR filter with inerpolation: r[j] = sum ( h[k] * x [j*D-k]), k=0..(nh-1) */
 void p_firint_f32(const float *x, const float *h, float *r,
-                  int nx, int nh, int ifactor, int p, p_team_t team);
+                  int nx, int nh, int ifactor);
 
 /*FIR symmetric form: */
-void p_firsym_f32(const float *x, const float *h, float *r, int nx, int nh,
-                  int p, p_team_t team);
+void p_firsym_f32(const float *x, const float *h, float *r, int nx, int nh);
 
 /*IIR filter: */
-void p_iir_f32(const float *x, const float *h, float *r, int nb, int nr,
-               int p, p_team_t team);
+void p_iir_f32(const float *x, const float *h, float *r, int nb, int nr);

--- a/include/pal_image.h
+++ b/include/pal_image.h
@@ -19,44 +19,34 @@
 
 /*2d convolution */
 void p_conv2d_f32(const float *x, float *m, float *r, int rows, int cols,
-                  int msize, int p, p_team_t team);
+                  int msize);
 
 /*2d box (i.e mean) filter(3x3) */
-void p_box3x3_f32(const float *x, float *r, int rows, int cols,
-                  int p, p_team_t team);
+void p_box3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d gauss filter (3x3) */
-void p_gauss3x3_f32(const float *x, float *r, int rows, int cols,
-                    int p, p_team_t team);
+void p_gauss3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d median filter (3x3) */
-void p_median3x3_f32(const float *x, float *r, int rows, int cols,
-                     int p, p_team_t team);
+void p_median3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d laplace filter (3x3) */
-void p_laplace3x3_f32(const float *x, float *r, int rows, int cols,
-                      int p, p_team_t team);
+void p_laplace3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d scharr filter (3x3) */
-void p_scharr3x3_f32(const float *x, float *r, int rows, int cols,
-                     int p, p_team_t team);
+void p_scharr3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d prewitt filter (3x3) */
-void p_prewitt3x3_f32(const float *x, float *r, int rows, int cols,
-                      int p, p_team_t team);
+void p_prewitt3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d sum of absolute differences (8x8), returns scalar */
-void p_sad8x8_f32(const float *x, float *m, float *r, int cols,
-                  int p, p_team_t team);
+void p_sad8x8_f32(const float *x, float *m, float *r, int cols);
 
 /*2d sum of absolute differences (16x16), returns scalar */
-void p_sad16x16_f32(const float *x, float *m, float *r, int cols,
-                    int p, p_team_t team);
+void p_sad16x16_f32(const float *x, float *m, float *r, int cols);
 
 /*2d sobel filter (3x3) */
-void p_sobel3x3_f32(const float *x, float *r, int rows, int cols,
-                    int p, p_team_t team);
+void p_sobel3x3_f32(const float *x, float *r, int rows, int cols);
 
 /*2d harris filter (3x3) */
-void p_harris3x3_f32(const float *x, float *r, float *t, int rows, int cols,
-                     int p, p_team_t team);
+void p_harris3x3_f32(const float *x, float *r, float *t, int rows, int cols);

--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -102,113 +102,103 @@
  */
 
 /*integer to float conversion*/
-void p_itof(const int *a, float *c, int n, int p, p_team_t team);
+void p_itof(const int *a, float *c, int n);
 
 /*float to integer conversion*/
-void p_ftoi(const float *a, int *c, int n, int p, p_team_t team);
+void p_ftoi(const float *a, int *c, int n);
 
 /*absolute value c = abs ( a ) */
-void p_abs_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_abs_f32(const float *a, float *c, int n);
 
 /*arc cosine: c = acos ( a ) */
-void p_acos_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_acos_f32(const float *a, float *c, int n);
 
 /*arc hyperbolic cosine, c = acosh ( a ) */
-void p_acosh_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_acosh_f32(const float *a, float *c, int n);
 
 /*arc sine: c = asin ( a ) */
-void p_asin_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_asin_f32(const float *a, float *c, int n);
 
 /*arc hyperbolic sine: c = asinh ( a ) */
-void p_asinh_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_asinh_f32(const float *a, float *c, int n);
 
 /*arc tanget: c = atan ( a ) */
-void p_atan_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_atan_f32(const float *a, float *c, int n);
 
 /*arc tangent of b/a: c = atan2 ( a , b) */
-void p_atan2_f32(const float *a, const float *b, float *c,
-                 int n, int p, p_team_t team);
+void p_atan2_f32(const float *a, const float *b, float *c, int n);
 
 /*arc hyperbolic tanget: c = atanh ( a ) */
-void p_atanh_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_atanh_f32(const float *a, float *c, int n);
 
 /*cubic root of a:  c = cbrt ( a) */
-void p_cbrt_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_cbrt_f32(const float *a, float *c, int n);
 
 /*cosine: c = cos ( a ) */
-void p_cos_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_cos_f32(const float *a, float *c, int n);
 
 /*hyperpolic cosine:  c = cosh ( a ) */
-void p_cosh_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_cosh_f32(const float *a, float *c, int n);
 
 /*division: c =  a ./ b */
-void p_div_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_div_f32(const float *a, const float *b, float *c, int n);
 
 /*exponential: c = exp ( a ) */
-void p_exp_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_exp_f32(const float *a, float *c, int n);
 
 /*inverse: c = 1 / ( a ) */
-void p_inv_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_inv_f32(const float *a, float *c, int n);
 
 /*inverse cube root: c = 1 / cbrt ( a ) */
-void p_invcbrt_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_invcbrt_f32(const float *a, float *c, int n);
 
 /*inverse square root c = 1 / sqrt ( a ) */
-void p_invsqrt_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_invsqrt_f32(const float *a, float *c, int n);
 
 /*natural logarithm: c = ln ( a ) */
-void p_ln_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_ln_f32(const float *a, float *c, int n);
 
 /*denary logarithm: c = log10 ( a ) */
-void p_log10_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_log10_f32(const float *a, float *c, int n);
 
 /*element raised to a power: c = pow ( a , b ) */
-void p_pow_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_pow_f32(const float *a, const float *b, float *c, int n);
 
 /*sine: c = sin ( a ) */
-void p_sin_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_sin_f32(const float *a, float *c, int n);
 
 /*computes sin and cos of a: c = sin ( a ),  z = cos ( a ) */
-void p_sincos_f32(const float *a, float *c, float *z,
-                  int n, int p, p_team_t team);
+void p_sincos_f32(const float *a, float *c, float *z, int n);
 
 /*hyperbolic Sine: c = sinh ( a ) */
-void p_sinh_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_sinh_f32(const float *a, float *c, int n);
 
 /*square root c = sqrt ( a ) */
-void p_sqrt_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_sqrt_f32(const float *a, float *c, int n);
 
 /*tangent: c = tan ( a ) */
-void p_tan_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_tan_f32(const float *a, float *c, int n);
 
 /*hyperbolic tangent, c = tanh ( a ) */
-void p_tanh_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_tanh_f32(const float *a, float *c, int n);
 
 /*dot product: c =  sum ( a[n-1:0] * b[n-1:0] ) */
-void p_dot_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_dot_f32(const float *a, const float *b, float *c, int n);
 
 /*absolute difference: c = | a[n-1:0] - b[n-1:0] | */
-void p_absdiff_f32(const float *a, const float *b, float *c,
-                   int n, int p, p_team_t team);
+void p_absdiff_f32(const float *a, const float *b, float *c, int n);
 
 /*add vectors: c =  a[n-1:0] + b[n-1:0]  */
-void p_add_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_add_f32(const float *a, const float *b, float *c, int n);
 
 /*subtract vectors: c =  a[n-1:0] - b[n-1:0]  */
-void p_sub_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_sub_f32(const float *a, const float *b, float *c, int n);
 
 /*multiply vectors: c =  a[n-1:0] - b[n-1:0]  */
-void p_mul_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_mul_f32(const float *a, const float *b, float *c, int n);
 
 /* Element wise multiply accumulate: c += a * b' */
-void p_mac_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team);
+void p_mac_f32(const float *a, const float *b, float *c, int n);
 
 /*
  ****************************************************************
@@ -224,30 +214,28 @@ void p_mac_f32(const float *a, const float *b, float *c,
  */
 
 /*sum: c = sum ( a[n-1:0] ) */
-void p_sum_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_sum_f32(const float *a, float *c, int n);
 
 /*sum of squares: c =  sum( a[n-1:0]^2 ) */
-void p_sumsq_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_sumsq_f32(const float *a, float *c, int n);
 
 /*mean: c = sum ( a[n-1:0] ) / n  */
-void p_mean_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_mean_f32(const float *a, float *c, int n);
 
 /*middle value: c = median ( a[n-1:0] ) */
-void p_median_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_median_f32(const float *a, float *c, int n);
 
 /*most common number: c = mode ( a[n-1:0] ) */
-void p_mode_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_mode_f32(const float *a, float *c, int n);
 
 /*standard deviation: c = sqrt ( mean ( ( a[n-1:0] - mean ( a[n-1:0] ) ) ^ 2 ) ) */
-void p_stddev_f32(const float *a, float *c, int n, int p, p_team_t team);
+void p_stddev_f32(const float *a, float *c, int n);
 
 /*find max value and its index from input vector */
-void p_max_f32(const float *a, float *c, int *index,
-               int n, int p, p_team_t team);
+void p_max_f32(const float *a, float *c, int *index, int n);
 
 /*find min value and its index from input vector */
-void p_min_f32(const float *a, float *c, int *index,
-               int n, int p, p_team_t team);
+void p_min_f32(const float *a, float *c, int *index, int n);
 
 /*
  ****************************************************************
@@ -257,8 +245,8 @@ void p_min_f32(const float *a, float *c, int *index,
  */
 
 /*sort an array*/
-void p_sort_f32(const float *a, float *c, int n, int p, p_team_t team);
-void p_sort_u32(const uint32_t *a, uint32_t *c, int n, int p, p_team_t team);
+void p_sort_f32(const float *a, float *c, int n);
+void p_sort_u32(const uint32_t *a, uint32_t *c, int n);
 
 /* seed pseudo-random number generator */
 void p_srand(unsigned int seed);
@@ -267,7 +255,5 @@ void p_srand(unsigned int seed);
 int p_rand(void);
 
 /*population count*/
-void p_popcount_u32(const uint32_t *a, uint32_t *c,
-                    int n, int p, p_team_t team);
-void p_popcount_u64(const uint64_t *a, uint64_t *c,
-                    int n, int p, p_team_t team);
+void p_popcount_u32(const uint32_t *a, uint32_t *c, int n);
+void p_popcount_u64(const uint64_t *a, uint64_t *c, int n);

--- a/src/dsp/p_acorr.c
+++ b/src/dsp/p_acorr.c
@@ -13,16 +13,11 @@
  *
  * @param nr    Size of output vector
  * 
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_acorr_f32(const float *x, float *r, int nx, int nr,
-                 int p, p_team_t team)
+void p_acorr_f32(const float *x, float *r, int nx, int nr)
 {
   int c_offset;
   int index;

--- a/src/dsp/p_conv.c
+++ b/src/dsp/p_conv.c
@@ -15,15 +15,10 @@
  *
  * @param nh      The number of coefficients of the filter
  *
- * @param p       Number of processor to use (task parallelism)
- *
- * @param team    Team to work with 
- *
  * @return        None
  *
  */
-void p_conv_f32(const float *x, const float *h, float *r,
-                int nx, int nh, int p, p_team_t team)
+void p_conv_f32(const float *x, const float *h, float *r, int nx, int nh)
 {
     const float *xc = x;
     float *rx = r;

--- a/src/dsp/p_fir.c
+++ b/src/dsp/p_fir.c
@@ -16,16 +16,11 @@
  *
  * @param nh    The number of coefficients of the filter.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_fir_f32(const float *x, const float *h, float *r, int nx, int nh,
-               int p, p_team_t team)
+void p_fir_f32(const float *x, const float *h, float *r, int nx, int nh)
 {
 
     int wrp; // delay line's current position.

--- a/src/dsp/p_firdec.c
+++ b/src/dsp/p_firdec.c
@@ -18,15 +18,11 @@
  *
  * @param df    Decimation factor. (1 output sample per 'd' input samples)
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 void p_firdec_f32(const float *x, const float *h, float *r,
-                  int nx, int nh, int df, int p, p_team_t team)
+                  int nx, int nh, int df)
 {
 
     /*PLACE CODE HERE*/

--- a/src/dsp/p_firint.c
+++ b/src/dsp/p_firint.c
@@ -19,16 +19,12 @@
  * @param ifactor Interpolation factor. 'ifactor' output samples produced
  *                for every 1 input sample
  *
- * @param p       Number of processor to use (task parallelism)
- *
- * @param team    Team to work with 
- *
  * @return        None
  *
  */
 
 void p_firint_f32(const float *x, const float *h, float *r, int nx, int nh,
-                  int ifactor, int p, p_team_t team)
+                  int ifactor)
 {
 
     /*PLACE CODE HERE*/

--- a/src/dsp/p_firsym.c
+++ b/src/dsp/p_firsym.c
@@ -18,16 +18,11 @@
  *
  * @param nh    The number of coefficients of the filter.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_firsym_f32(const float *x, const float *h, float *r, int nx, int nh,
-                  int p, p_team_t team)
+void p_firsym_f32(const float *x, const float *h, float *r, int nx, int nh)
 {
 
     /*PLACE CODE HERE*/

--- a/src/dsp/p_iir.c
+++ b/src/dsp/p_iir.c
@@ -15,10 +15,6 @@
  *
  * @param nr    Size of input and output vectors
  * 
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
@@ -32,8 +28,7 @@ float coeffs[_Nstage][2][_Ntaps+1]  =
 	{{/*IIR-0*/ {1, 0.5, 0, 0}, /*FIR-0*/ {0.5, 0.5, 0, 0}},
 	 {/*IIR-1*/ {1, 0,   0, 0}, /*FIR-1*/ {0,   0,   0, 0}}};
 
-void p_iir_f32(const float *x, const float *h, float *r, int nb, int nr,
-               int p, p_team_t team)
+void p_iir_f32(const float *x, const float *h, float *r, int nb, int nr)
 {
 	int register rdp; // pointer to the I/O data's current position.
 	int register cp;  // pointer to the coefficients array.

--- a/src/dsp/p_xcorr.c
+++ b/src/dsp/p_xcorr.c
@@ -16,16 +16,11 @@
  *
  * @param ny    Number of elements in vector 'y'
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_xcorr_f32(const float *x, const float *y, float *r, int nx, int ny,
-                 int p, p_team_t team)
+void p_xcorr_f32(const float *x, const float *y, float *r, int nx, int ny)
 {
   const float* data1_p;
   const float* data2_p;

--- a/src/image/p_box3x3.c
+++ b/src/image/p_box3x3.c
@@ -18,8 +18,7 @@
  *
  */
 
-void p_box3x3_f32(const float *x, float *r, int rows, int cols,
-                  int p, p_team_t team)
+void p_box3x3_f32(const float *x, float *r, int rows, int cols)
 {
 
     int ia, ja;

--- a/src/image/p_conv2d.c
+++ b/src/image/p_conv2d.c
@@ -14,16 +14,12 @@
  *
  * @param msize Size of convolution kernel
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
 void p_conv2d_f32(const float *x, float *m, float *r, int rows, int cols,
-                  int msize, int p, p_team_t team)
+                  int msize)
 
 {
     int i, j, k;
@@ -40,7 +36,7 @@ void p_conv2d_f32(const float *x, float *m, float *r, int rows, int cols,
             P = 0.0f;
             pm = m;
             for (k = 0; k < msize; k++) {
-                p_dot_f32(px, pm, &part, msize, 0, team);
+                p_dot_f32(px, pm, &part, msize);
                 P += part;
                 px += cols;
                 pm += msize;

--- a/src/image/p_gauss3x3.c
+++ b/src/image/p_gauss3x3.c
@@ -15,16 +15,11 @@
  *
  * @param cols Number of columns in input image
  *
- * @param p    Number of processor to use (task parallelism)
- *
- * @param team Team to work with
- *
  * @return     None
  *
  */
 
-void p_gauss3x3_f32(const float *x, float *r, int rows, int cols,
-                    int p, p_team_t team)
+void p_gauss3x3_f32(const float *x, float *r, int rows, int cols)
 {
     int i, j;
 	int rm2 = rows - 2;

--- a/src/image/p_harris3x3.c
+++ b/src/image/p_harris3x3.c
@@ -1,8 +1,7 @@
 #include <pal.h>
 
 /* smooth structure tensor */
-static void _sst3x3(const float *x, float *r, int rows, int cols, 
-		    int p, p_team_t team)
+static void _sst3x3(const float *x, float *r, int rows, int cols)
 {
     int i, j;
     int ic3 = 1 - 3 * cols;
@@ -64,13 +63,8 @@ static void _sst3x3(const float *x, float *r, int rows, int cols,
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  */
-void p_harris3x3_f32(const float *x, float *r, float *t, int rows, int cols, 
-		    int p, p_team_t team)
+void p_harris3x3_f32(const float *x, float *r, float *t, int rows, int cols)
 {
 	int i, j;
 	int rm4 = rows - 4;
@@ -83,7 +77,7 @@ void p_harris3x3_f32(const float *x, float *r, float *t, int rows, int cols,
     pr = r;
     pt = t;
     
-    _sst3x3(x, t, rows, cols, p, team);
+    _sst3x3(x, t, rows, cols);
 	
     for (i = 0; i < rm4; i++) {
         for (j = 0; j < cm4; j++) {

--- a/src/image/p_laplace3x3.c
+++ b/src/image/p_laplace3x3.c
@@ -15,15 +15,10 @@
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_laplace3x3_f32(const float *x, float *r, int rows, int cols,
-                      int p, p_team_t team)
+void p_laplace3x3_f32(const float *x, float *r, int rows, int cols)
 {
 
     int ia, ja;

--- a/src/image/p_median3x3.c
+++ b/src/image/p_median3x3.c
@@ -11,16 +11,11 @@
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_median3x3_f32(const float *x, float *r, int rows, int cols,
-                     int p, p_team_t team)
+void p_median3x3_f32(const float *x, float *r, int rows, int cols)
 {
     float buffer[9];
     const float *px;
@@ -44,7 +39,7 @@ void p_median3x3_f32(const float *x, float *r, int rows, int cols,
         buffer[7] = *(px + cols + cols + 1);
         buffer[8] = *(px + cols + cols + 2);
 
-        p_median_f32(buffer, pr, 9, 0, 0);
+        p_median_f32(buffer, pr, 9);
         pr++;
         px += 3;
         // other windows differ only by one column
@@ -55,7 +50,7 @@ void p_median3x3_f32(const float *x, float *r, int rows, int cols,
             buffer[buffer_col + 3] = *(px + cols);
             buffer[buffer_col + 6] = *(px + cols + cols);
 
-            p_median_f32(buffer, pr, 9, 0, 0);
+            p_median_f32(buffer, pr, 9);
             pr++;
             px++;
         }

--- a/src/image/p_prewitt3x3.c
+++ b/src/image/p_prewitt3x3.c
@@ -23,15 +23,10 @@
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_prewitt3x3_f32(const float *x,  float *r, int rows, int cols,
-                      int p, p_team_t team)
+void p_prewitt3x3_f32(const float *x,  float *r, int rows, int cols)
 {
 
     int ia, ja;

--- a/src/image/p_sad16x16.c
+++ b/src/image/p_sad16x16.c
@@ -12,15 +12,10 @@
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_sad16x16_f32(const float *x, float *m, float *r, int cols,
-                    int p, p_team_t team)
+void p_sad16x16_f32(const float *x, float *m, float *r, int cols)
 {
 
      /*pseudo code

--- a/src/image/p_sad8x8.c
+++ b/src/image/p_sad8x8.c
@@ -12,15 +12,10 @@
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  */
 
-void p_sad8x8_f32(const float *x, float *m, float *r, int cols,
-                  int p, p_team_t team)
+void p_sad8x8_f32(const float *x, float *m, float *r, int cols)
 {
       /*pseudo code
        for (i = 0; i < 8; i++)

--- a/src/image/p_scharr3x3.c
+++ b/src/image/p_scharr3x3.c
@@ -23,13 +23,8 @@
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  */
 
-void p_scharr3x3_f32(const float *x, float *r, int rows, int cols,
-                     int p, p_team_t team)
+void p_scharr3x3_f32(const float *x, float *r, int rows, int cols)
 {
 }

--- a/src/image/p_sobel3x3.c
+++ b/src/image/p_sobel3x3.c
@@ -25,14 +25,9 @@ static __inline __attribute((__always_inline__)) float my_hypot( float a, float 
  *
  * @param cols  Number of columns in input image
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with
- *
  */
 
-void p_sobel3x3_f32(const float *x, float *r, int rows, int cols,
-                    int p, p_team_t team)
+void p_sobel3x3_f32(const float *x, float *r, int rows, int cols)
 {
 	int i, j;
 	float Gx, Gy;

--- a/src/math/examples/main_p_sin_f32.c
+++ b/src/math/examples/main_p_sin_f32.c
@@ -15,7 +15,6 @@ int main(int argc, char **argv)
 
     float testval;
     int n;   
-    p_team_t team;
     int i;
 
     while ( (opt = getopt(argc, argv, "f:n:")) != -1) {
@@ -43,7 +42,7 @@ int main(int argc, char **argv)
       }
 
     //Execute
-    p_sin_f32(a, c, n, 0, team);    
+    p_sin_f32(a, c, n);    
     
     //Print result
     for (i=0;i<n;i++){

--- a/src/math/p_a_inv.c
+++ b/src/math/p_a_inv.c
@@ -12,16 +12,11 @@
  *
  * @param it    The number of iterations to run; also, a function of the maximum magnitude that can be run.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_a_inv_f32(const float *a, float *c, int n, int p,
-                 int iterations, p_team_t team)
+void p_a_inv_f32(const float *a, float *c, int n, int iterations)
 {
     int i, j;
     float max = iterations * iterations * iterations;

--- a/src/math/p_abs.c
+++ b/src/math/p_abs.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_abs_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_abs_f32(const float *a, float *c, int n)
 {
     uint32_t tmp;
     int i;

--- a/src/math/p_absdiff.c
+++ b/src/math/p_absdiff.c
@@ -12,16 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_absdiff_f32(const float *a, const float *b, float *c,
-                   int n, int p, p_team_t team)
+void p_absdiff_f32(const float *a, const float *b, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_acos.c
+++ b/src/math/p_acos.c
@@ -12,15 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_acos_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_acos_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_acosh.c
+++ b/src/math/p_acosh.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_acosh_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_acosh_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_add.c
+++ b/src/math/p_add.c
@@ -12,16 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_add_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team)
+void p_add_f32(const float *a, const float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_asin.c
+++ b/src/math/p_asin.c
@@ -12,15 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_asin_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_asin_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_asinh.c
+++ b/src/math/p_asinh.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_asinh_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_asinh_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_atan.c
+++ b/src/math/p_atan.c
@@ -12,15 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  * 
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_atan_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_atan_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_atan2.c
+++ b/src/math/p_atan2.c
@@ -13,16 +13,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_atan2_f32(const float *a, const float *b, float *c,
-                 int n, int p, p_team_t team)
+void p_atan2_f32(const float *a, const float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_atanh.c
+++ b/src/math/p_atanh.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_atanh_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_atanh_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_cbrt.c
+++ b/src/math/p_cbrt.c
@@ -12,14 +12,10 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_cbrt_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_cbrt_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_cos.c
+++ b/src/math/p_cos.c
@@ -11,17 +11,13 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
 #define COS_ITERATIONS 5
 
-void p_cos_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_cos_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_cosh.c
+++ b/src/math/p_cosh.c
@@ -11,16 +11,12 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
 #include <math.h>
-void p_cosh_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_cosh_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_div.c
+++ b/src/math/p_div.c
@@ -12,16 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_div_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team)
+void p_div_f32(const float *a, const float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_dot.c
+++ b/src/math/p_dot.c
@@ -13,15 +13,10 @@
  *
  * @param n     Size of 'a', 'b'
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_dot_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team )
+void p_dot_f32(const float *a, const float *b, float *c, int n )
 {
     float tmp = 0.0f;
     int i;

--- a/src/math/p_exp.c
+++ b/src/math/p_exp.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_exp_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_exp_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_ftoi.c
+++ b/src/math/p_ftoi.c
@@ -12,15 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_ftoi(const float *a, int *c, int n, int p, p_team_t team)
+void p_ftoi(const float *a, int *c, int n)
 {
     uint32_t tmp;
     float rounding_value;

--- a/src/math/p_inv.c
+++ b/src/math/p_inv.c
@@ -10,16 +10,12 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
 
-void p_inv_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_inv_f32(const float *a, float *c, int n)
 {
     int i;
     float cur;

--- a/src/math/p_invcbrt.c
+++ b/src/math/p_invcbrt.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_invcbrt_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_invcbrt_f32(const float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_invsqrt.c
+++ b/src/math/p_invsqrt.c
@@ -15,15 +15,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- **
  * @return      None
  *
  */
 #include <math.h>
-void p_invsqrt_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_invsqrt_f32(const float *a, float *c, int n)
 {
     // This union allows us to type-pun between integers and floats
     // with fewer strict aliasing concerns than the pointer casts

--- a/src/math/p_itof.c
+++ b/src/math/p_itof.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_itof(const int *a, float *c, int n, int p, p_team_t team)
+void p_itof(const int *a, float *c, int n)
 {
     for(int i = 0; i < n; i++)
         *(c + i) = (float)(*(a + i));

--- a/src/math/p_ln.c
+++ b/src/math/p_ln.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_ln_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_ln_f32(const float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_log10.c
+++ b/src/math/p_log10.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_log10_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_log10_f32(const float *a, float *c, int n)
 {
 
     int i;

--- a/src/math/p_mac.c
+++ b/src/math/p_mac.c
@@ -12,16 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_mac_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team)
+void p_mac_f32(const float *a, const float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_max.c
+++ b/src/math/p_max.c
@@ -12,16 +12,11 @@
  *
  * @param n      Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return       None
  *
  */
 
-void p_max_f32(const float *a, float *c, int *index,
-               int n, int p, p_team_t team)
+void p_max_f32(const float *a, float *c, int *index, int n)
 {
     if (n==0) return; // only do work if there are elements
     int pos = 0;

--- a/src/math/p_mean.c
+++ b/src/math/p_mean.c
@@ -10,14 +10,10 @@
  *
  * @param n     Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_mean_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_mean_f32(const float *a, float *c, int n)
 {
     float tmp = 0.0f;
     int i;

--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -39,15 +39,11 @@ static unsigned int median_partition(float *a,
  *
  * @param n     Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_median_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_median_f32(const float *a, float *c, int n)
 {
     unsigned int left = 0;
     unsigned int median_index = (n - 1) >> 1;

--- a/src/math/p_min.c
+++ b/src/math/p_min.c
@@ -13,15 +13,10 @@
  *
  * @param n           Size of 'a' vector.
  * 
- * @param p           Number of processor to use (task parallelism)
- *
- * @param team        Team to work with 
- *
  * @return            None
  *
  */
-void p_min_f32(const float *a, float *c, int *index,
-               int n, int p, p_team_t team)
+void p_min_f32(const float *a, float *c, int *index, int n)
 {
     float min;
     int i, pos;

--- a/src/math/p_mode.c
+++ b/src/math/p_mode.c
@@ -10,22 +10,18 @@
  *
  * @param n     Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_mode_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_mode_f32(const float *a, float *c, int n)
 {
     unsigned int occurrence_count = 0;
     unsigned int max_occurrence_count = 0;
     unsigned int i = 1;
     float mode_value = 0.0f;
-    float *sorted_a = (float*) p_malloc(team, sizeof(float) * n);
-    p_sort_f32(a, sorted_a, n, p, team);
+    float *sorted_a = (float*) malloc(sizeof(float) * n);
+    p_sort_f32(a, sorted_a, n);
 
     for (; i < n; ++i) {
         ++occurrence_count;

--- a/src/math/p_mul.c
+++ b/src/math/p_mul.c
@@ -12,16 +12,12 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
 void p_mul_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team)
+               int n)
 {
 
     int i;

--- a/src/math/p_popcount.c
+++ b/src/math/p_popcount.c
@@ -10,14 +10,10 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
-void p_popcount_u32(const uint32_t *a, uint32_t *c, int n, int p, p_team_t team)
+void p_popcount_u32(const uint32_t *a, uint32_t *c, int n)
 {
     static const uint32_t A[] = {0x55555555, 0x33333333,
                                  0x0f0f0f0f, 0x01010101};
@@ -38,7 +34,7 @@ void p_popcount_u32(const uint32_t *a, uint32_t *c, int n, int p, p_team_t team)
     }
 }
 
-void p_popcount_u64(const uint64_t *a, uint64_t *c, int n, int p, p_team_t team)
+void p_popcount_u64(const uint64_t *a, uint64_t *c, int n)
 {
     static const uint64_t A[] = {0x5555555555555555, 0x3333333333333333,
                                  0x0f0f0f0f0f0f0f0f, 0x0101010101010101};

--- a/src/math/p_pow.c
+++ b/src/math/p_pow.c
@@ -12,16 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_pow_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team)
+void p_pow_f32(const float *a, const float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_sin.c
+++ b/src/math/p_sin.c
@@ -11,17 +11,13 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
 #define SIN_ITERATIONS 5
 
-void p_sin_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_sin_f32(const float *a, float *c, int n)
 {
     int i;    
     for (i = 0; i < n; i++) {

--- a/src/math/p_sincos.c
+++ b/src/math/p_sincos.c
@@ -15,16 +15,12 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  * 
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 void p_sincos_f32(const float *a, float *c, float *z,
-                  int n, int p, p_team_t team)
+                  int n)
 {
-    p_sin_f32(a, c, n, 0, team);
-    p_cos_f32(a, z, n, 0, team);
+    p_sin_f32(a, c, n);
+    p_cos_f32(a, z, n);
 }

--- a/src/math/p_sinh.c
+++ b/src/math/p_sinh.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_sinh_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_sinh_f32(const float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_sort.c
+++ b/src/math/p_sort.c
@@ -70,13 +70,11 @@ SORT_FUNC(_heapsort_u32, uint32_t, _sift_down_u32);
  * @param a     Pointer to input vector
  * @param c     Pointer to result vector
  * @param n     Size of 'a' and 'c' vector.
- * @param p     Number of processor to use (task parallelism)
- * @param team  Team to work with 
  *
  * @return      None
  *
  */
-void p_sort_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_sort_f32(const float *a, float *c, int n)
 {
 	_heapsort_f32(a, c, n);
 }
@@ -88,13 +86,11 @@ void p_sort_f32(const float *a, float *c, int n, int p, p_team_t team)
  * @param a     Pointer to input vector
  * @param c     Pointer to result vector
  * @param n     Size of 'a' and 'c' vector.
- * @param p     Number of processor to use (task parallelism)
- * @param team  Team to work with 
  *
  * @return      None
  *
  */
-void p_sort_u32(const uint32_t *a, uint32_t *c, int n, int p, p_team_t team)
+void p_sort_u32(const uint32_t *a, uint32_t *c, int n)
 {
 	_heapsort_u32(a, c, n);
 }

--- a/src/math/p_sqrt.c
+++ b/src/math/p_sqrt.c
@@ -17,16 +17,12 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
 
-void p_sqrt_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_sqrt_f32(const float *a, float *c, int n)
 {
     
     int i;

--- a/src/math/p_stddev.c
+++ b/src/math/p_stddev.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_stddev_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_stddev_f32(const float *a, float *c, int n)
 {
     float tmp = 0.0f, mean = 0.0f, meansq = 0.0f;
     int i;

--- a/src/math/p_sub.c
+++ b/src/math/p_sub.c
@@ -12,16 +12,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  * 
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_sub_f32(const float *a, const float *b, float *c,
-               int n, int p, p_team_t team)
+void p_sub_f32(const float *a, const float *b, float *c, int n)
 {
 
     int i;

--- a/src/math/p_sum.c
+++ b/src/math/p_sum.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_sum_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_sum_f32(const float *a, float *c, int n)
 {
     float tmp = 0.0f;
     int i;

--- a/src/math/p_sumsq.c
+++ b/src/math/p_sumsq.c
@@ -10,15 +10,11 @@
  *
  * @param n     Size of 'a' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 
-void p_sumsq_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_sumsq_f32(const float *a, float *c, int n)
 {
     float tmp = 0.0f;
     int i;

--- a/src/math/p_tan.c
+++ b/src/math/p_tan.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_tan_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_tan_f32(const float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/src/math/p_tanh.c
+++ b/src/math/p_tanh.c
@@ -11,15 +11,11 @@
  *
  * @param n     Size of 'a' and 'c' vector.
  *
- * @param p     Number of processor to use (task parallelism)
- *
- * @param team  Team to work with 
- *
  * @return      None
  *
  */
 #include <math.h>
-void p_tanh_f32(const float *a, float *c, int n, int p, p_team_t team)
+void p_tanh_f32(const float *a, float *c, int n)
 {
     int i;
     for (i = 0; i < n; i++) {

--- a/tests/dsp/check_p_acorr.c
+++ b/tests/dsp/check_p_acorr.c
@@ -45,31 +45,12 @@ int main(int argc, char *argv[])
 {
 
     // Stack variables
-    char *file = "./e_test.elf";
-    char *func = "main";
-    int status, i, all, nargs = 1;
-    char *args[nargs];
-    char argbuf[20];
+    int i;
     float test_out[out_size];
     int testOK = 1;
 
-    // References as opaque structures
-    p_dev_t dev0;
-    p_prog_t prog0;
-    p_team_t team0;
-    p_mem_t mem[4];
-
-  printf("Running test program p_acorr_test...\n");
-  //   printf("   Cycles measured for %d samples\n",in_size);
-    // Execution setup
-    dev0 = p_init(P_DEV_DEMO, 0);        // initialize device and team
-    prog0 = p_load(dev0, file, func, 0); // load a program from file system
-    all = p_query(dev0, P_PROP_NODES);   // find number of nodes in system
-    team0 = p_open(dev0, 0, all);        // create a team
-
-
     // Run the test on Arm
-    p_acorr_f32(in, test_out, in_size, out_size,1, team0);
+    p_acorr_f32(in, test_out, in_size, out_size);
 
     // Check data
     for ( i = 0; i < out_size; i++ ) {
@@ -84,16 +65,6 @@ int main(int argc, char *argv[])
     } else {
       printf("Acorr ARM test FAILED!!\n");
     }
-    // Running program
-    /* for (i = 0; i < 1; i++) {  // was all */
-    /*     sprintf(argbuf, "%d", i); // string args needed to run main asis */
-    /*     args[0] = argbuf; */
-    /*     status = p_run(prog0, team0, i, 1, nargs, args, 0); */
-    /* } */
-
-    p_wait(team0);    // not needed
-    p_close(team0);   // close team
-    p_finalize(dev0); // finalize memory
 
 }
 

--- a/tests/dsp/check_p_xcorr.c
+++ b/tests/dsp/check_p_xcorr.c
@@ -49,14 +49,11 @@ int main(int argc, char *argv[])
     int testOK = 1;
     int i;
 
-    // References as opaque structures
-    p_team_t team0;
-
   printf("Running test program p_xcorr_test...\n");
     // Execution setup
 
     // Run test 1 on Arm
-    p_xcorr_f32(in11, in12, test_out, in11_size, in12_size, 1, team0);
+    p_xcorr_f32(in11, in12, test_out, in11_size, in12_size);
 
     // Check data
     for ( i = 0; i < out_size1; i++ ) {
@@ -67,7 +64,7 @@ int main(int argc, char *argv[])
     }
 
     // Run test 2 on Arm
-    p_xcorr_f32(in21, in22, test_out, in21_size, in22_size, 1, team0);
+    p_xcorr_f32(in21, in22, test_out, in21_size, in22_size);
 
     // Check data
     for ( i = 0; i < out_size2; i++ ) {

--- a/tests/math/simple.c
+++ b/tests/math/simple.c
@@ -58,14 +58,10 @@ void setup()
 
     /* Run FUNCTION against gold input here so results are available
      * for all test cases. */
-    /* HACK: Pass in an invalid team. API was changed in:
-     * a380f6b70b8461dbb8c0def388d00270f8b27c28
-     * but implementation did have not catched up yet.
-     * When it does, the tests will break... */
 #if IS_UNARY
-    FUNCTION(ai, res, ARRAY_SIZE(gold), 0, p_ref_err(EINVAL));
+    FUNCTION(ai, res, ARRAY_SIZE(gold));
 #else /* Binary */
-    FUNCTION(ai, bi, res, ARRAY_SIZE(gold), 0, p_ref_err(EINVAL));
+    FUNCTION(ai, bi, res, ARRAY_SIZE(gold));
 #endif
 }
 


### PR DESCRIPTION
Remove team parameter from API functions in:
image
dsp
math

None of this was implemented and parallelism should be handled in an
upper layer API.

Signed-off-by: Ola Jeppsson <ola@adapteva.com>