### PR TITLE
Ignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ Makefile.in
 
 # Erlang
 *.beam
+
+# Gold test headers (generated from .dat files)
+*.gold.h

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@
 *.la
 *.lo
 
+# Static Usage
+*.su
+
 # Shared objects (inc. Windows DLLs)
 *.dll
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,12 @@ Makefile.in
 
 # Gold test headers (generated from .dat files)
 *.gold.h
+
+# Test outputs
+tests/math/rangen
+tests/runtest
+tests/*.log
+tests/*.sum
+tests/*/check_p_*
+tests/*/*.log
+tests/*/.libs/

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Libraries
 *.lib
+.libs/
 *.a
 *.la
 *.lo
@@ -65,4 +66,4 @@ tests/*.log
 tests/*.sum
 tests/*/check_p_*
 tests/*/*.log
-tests/*/.libs/
+


### PR DESCRIPTION
`git status` gives a massive list of files after a clean checkout and make, this mod reduces that to about half a dozen that may need to be ignored by name.