### PR TITLE
Optimize p_box3x3_f32 function

### DIFF
--- a/src/image/p_box3x3.c
+++ b/src/image/p_box3x3.c
@@ -21,35 +21,97 @@
 void p_box3x3_f32(const float *x, float *r, int rows, int cols)
 {
 
-    int ia, ja;
-    float E;
+    int i, j;
+    float sum;
     const float *px;
     float *pr;
 
     px = x;
     pr = r;
 
-    for (ia = 1; ia <= (rows - 2); ia++) {
-        for (ja = 1; ja <= (cols - 2); ja++) {
-            E = 0;
-            E += (*px++);
-            E += (*px++);
-            E += (*px++);
-            px += cols - 3;
-            E += (*px++);
-            E += (*px++);
-            E += (*px++);
-            px += cols - 3;
-            E += (*px++);
-            E += (*px++);
-            E += (*px++);
-            px += cols - 3;
-            *pr = E * M_DIV9;
-            px += 1 - 3 * cols; // advance mask matrix in one column.
+    // Process first row
+
+    // Calculate the first sum
+    sum = (*px) + (*(px+1)) + (*(px+2));
+    // The sums from the first row are only used for a single row of the output.
+    *pr = sum;
+    pr++;
+    for (j = 3; j < cols; j++) {
+        // All subsequent sums are calculated by removing the leftmost
+        // value, and adding the next.
+        sum += (*(px+3)) - (*px);
+        *pr = sum;
+        px++;
+        pr++;
+    }
+    px += 3; // Advance input pointer to beginning of next row.
+    pr = r;
+
+    // Process second row
+
+    sum = (*px) + (*(px+1)) + (*(px+2));
+    // The second row's sums are added to the first row's, and used to
+    // initialize a new output row.
+    *pr += sum;
+    *(pr+cols-2) = sum;
+    pr++;
+    for (j = 3; j < cols; j++) {
+        sum += (*(px+3)) - (*px);
+        *pr += sum;
+        *(pr+cols-2) = sum;
+        px++;
+        pr++;
+    }
+    px += 3; // Advance input pointer to beginning of next row.
+
+    // Process (rows - 4) middle rows
+
+    for (i = 4; i < rows; i++) {
+        // These rows are the final inclusion to the output row from two
+        // iterations ago (so the final division is applied). They are also
+        // added to the previous row's output and used to initialize the
+        // next row.
+        sum = (*px) + (*(px+1)) + (*(px+2));
+        *(pr-cols+2) = (*(pr-cols+2) + sum) * M_DIV9;
+        *pr += sum;
+        *(pr+cols-2) = sum;
+        pr++;
+        for (j = 3; j < cols; j++) {
+            sum += (*(px+3)) - (*px);
+            *(pr-cols+2) = (*(pr-cols+2) + sum) * M_DIV9;
+            *pr += sum;
+            *(pr+cols-2) = sum;
+            px++;
             pr++;
         }
-        px = px + 2; // advance pointer to the beginning of next row.
+        px += 3; // Advance input pointer to beginning of next row.
     }
 
-    return;
+    // Process second-to-last row
+
+    sum = (*px) + (*(px+1)) + (*(px+2));
+    *(pr-cols+2) = (*(pr-cols+2) + sum) * M_DIV9;
+    *pr += sum;
+    pr++;
+    for (j = 3; j < cols; j++) {
+        sum += (*(px+3)) - (*px);
+        *(pr-cols+2) = (*(pr-cols+2) + sum) * M_DIV9;
+        *pr += sum;
+        px++;
+        pr++;
+    }
+    px += 3; // Advance input pointer to beginning of next row.
+    pr -= cols-2; // Reset output pointer to the previous row.
+
+    // Process last row
+
+    sum = (*px) + (*(px+1)) + (*(px+2));
+    *pr = (*(pr) + sum) * M_DIV9;
+    pr++;
+    for (j = 3; j < cols; j++) {
+        sum += (*(px+3)) - (*px);
+        *pr = (*(pr) + sum) * M_DIV9;
+        px++;
+        pr++;
+    }
 }


### PR DESCRIPTION
The current box filter function is replaced with one that takes just over 50% of original running time, and the performance is ~150% that of the OpenCV equivalent (~2/3 of the OpenCV running time).