### PR TITLE
math: reimplement pow() as a combination of exp() and ln().

### DIFF
--- a/src/math/p_pow.c
+++ b/src/math/p_pow.c
@@ -15,12 +15,17 @@
  * @return      None
  *
  */
-#include <math.h>
+
 void p_pow_f32(const float *a, const float *b, float *c, int n)
 {
-
-    int i;
-    for (i = 0; i < n; i++) {
-        *(c + i) = powf(*(a + i), *(b + i));
-    }
+    int i = 0;
+    float x, *c_ = c;
+    const float *a_ = a, *b_ = b;
+    while (i < n) {
+		/* a^b = e^(b*ln(a)) */
+		p_ln_f32(a_++, &x, 1);
+		x *= *b_++;
+		p_exp_f32(&x, c_++, 1);
+		++i;
+	}
 }


### PR DESCRIPTION
This is very simple reimplementation of pow(). I am not sure if this is desirable to merge, though, but I am putting it here for discussion.

The patch just exploits the fact that a^b = e^(b*ln(a)). I don't know how fast it is. I know it loses some accuracy (due to optimized logf function). Is there a way to test the performance and accuracy?