### PR TITLE
Warnings in the build process / treat as errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
 
 script:
     - ./bootstrap
-    - ./configure
+    - ./configure "CFLAGS=-Werror"
     - echo Build using $(nproc) parallel jobs
     - make -j$(nproc)
     - make check

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ sudo apt-get install libtool build-essential pkg-config autoconf doxygen check
 
 ``` bash
 $ ./bootstrap
-$ ./configure
+$ ./configure "CFLAGS=-Werror"
 $ make
 ```
 


### PR DESCRIPTION
People are starting to commit code for which the compiler gives warnings. This can be dangerous as it might hide bugs, and could break the code in the future. The solution to this problem is the -Werror compiler flag, which treats warnings as errors.

This pull request shouldn't be merged atm, as it will break the build process. I created it more to start a discussion on this topic. 

Changes.
Modified readme and the travis configuration file as to treat warnings as errors.