### PR TITLE
Update p_median.c

### DIFF
--- a/src/math/p_median.c
+++ b/src/math/p_median.c
@@ -48,7 +48,7 @@ void p_median_f32(const float *a, float *c, int n)
     unsigned int left = 0;
     unsigned int median_index = (n - 1) >> 1;
     float median_value = 0.0f;
-    float search_a[n];
+    float *search_a = malloc(n * sizeof(float));
 
     memcpy(search_a, a, sizeof(float) * n);
 
@@ -71,4 +71,5 @@ void p_median_f32(const float *a, float *c, int n)
     }
 
     *c = (n % 2 ? median_value : median_value * 0.5);
+    free(search_a);
 }


### PR DESCRIPTION
The use of variable length arrays (VLA) without any size range checking is a security weakness that can be used to provoke a stack overflow that may lead to an arbitrary code execution vulnerability.

My proposed fix simply uses dynamic memory allocation over VLA.

For more information regarding proper use of VLA, please read: 
https://www.securecoding.cert.org/confluence/display/c/ARR32-C.+Ensure+size+arguments+for+variable+length+arrays+are+in+a+valid+range