### PR TITLE
Build on OS X

### DIFF
--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -23,27 +23,25 @@ static const size_t max_output = 3;
 #include <time.h>
 #endif
 
-typedef struct timespec platform_clock_t;
+typedef uint64_t platform_clock_t;
 
 #if defined(HAVE_CLOCK_GETTIME)
 static platform_clock_t platform_clock(void)
 {
     struct timespec ts;
+    uint64_t nanosec;
 
     clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+    nanosec = (uint64_t) ts.tv_sec * 1000000000UL + (uint64_t) ts.tv_nsec;
 
-    return ts;
+    return nanosec;
 }
 #endif
 
 static void platform_print_duration(platform_clock_t start,
                                     platform_clock_t end)
 {
-    uint64_t duration;
-    duration = ((uint64_t) (end.tv_sec - start.tv_sec) * 1000000000UL) +
-               end.tv_nsec - start.tv_nsec;
-
-    printf("%ju", duration);
+    printf("%" PRIu64, end - start);
 }
 
 /* end of platform specific section */

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -7,6 +7,7 @@
 #include <inttypes.h>
 #include <errno.h>
 
+#include "config.h"
 #include "benchmark.h"
 
 /* The ratio of the largest known output to input
@@ -18,7 +19,9 @@ static const size_t max_output = 3;
  * this prototype is posix specific
  */
 
+#if defined(HAVE_TIME_H)
 #include <time.h>
+#endif
 
 typedef struct timespec platform_clock_t;
 

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -25,6 +25,7 @@ static const size_t max_output = 3;
 
 typedef struct timespec platform_clock_t;
 
+#if defined(HAVE_CLOCK_GETTIME)
 static platform_clock_t platform_clock(void)
 {
     struct timespec ts;
@@ -33,6 +34,7 @@ static platform_clock_t platform_clock(void)
 
     return ts;
 }
+#endif
 
 static void platform_print_duration(platform_clock_t start,
                                     platform_clock_t end)

--- a/benchmark/benchmark.c
+++ b/benchmark/benchmark.c
@@ -38,6 +38,28 @@ static platform_clock_t platform_clock(void)
 }
 #endif
 
+#if defined(HAVE_MACH_TIME)
+#include <mach/mach_time.h>
+static platform_clock_t platform_clock(void)
+{
+    static mach_timebase_info_data_t tb_info = {
+        .numer = 0,
+        .denom = 0,
+    };
+    uint64_t abs_time, nanosec;
+
+    abs_time = mach_absolute_time();
+    if (tb_info.denom == 0) {
+        (void) mach_timebase_info(&tb_info);
+    }
+    nanosec = abs_time;
+    nanosec /= tb_info.denom;
+    nanosec *= tb_info.numer;
+
+    return nanosec;
+}
+#endif
+
 static void platform_print_duration(platform_clock_t start,
                                     platform_clock_t end)
 {

--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ LT_INIT
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([fcntl.h fenv.h float.h inttypes.h limits.h stddef.h stdint.h stdlib.h string.h strings.h sys/ioctl.h sys/time.h unistd.h])
+AC_CHECK_HEADERS([fcntl.h fenv.h float.h inttypes.h limits.h stddef.h stdint.h stdlib.h string.h strings.h sys/ioctl.h time.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,9 @@ LT_INIT
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h fenv.h float.h inttypes.h limits.h stddef.h stdint.h stdlib.h string.h strings.h sys/ioctl.h time.h unistd.h])
+AC_CHECK_HEADER([mach/mach_time.h],
+  [AC_DEFINE([HAVE_MACH_TIME], [1],
+    [Define to 1 if you have <mach/mach_time.h>])])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL


### PR DESCRIPTION
Hi,

I would like to build PAL on OS X, but OS X doesn't provide the `clock_gettime` function.

I had to make a couple changes in the file `benchmark.c`. I first switched the `platform_clock_t` structure to the type `uint64_t` which is more portable since the `timespec` structure is an extension to the C standard. Then I added a `platform_clock` function for OS X which does the same thing as the one which uses `clock_gettime`.

Now everything builds fine on OS X.