### PR TITLE
dsp:conv: reducing number of operations and deleting innecessary variables

### DIFF
--- a/src/dsp/p_conv.c
+++ b/src/dsp/p_conv.c
@@ -20,17 +20,14 @@
  */
 void p_conv_f32(const float *x, const float *h, float *r, int nx, int nh)
 {
-    const float *xc = x;
-    float *rx = r;
-    int i,j ;
-        for ( i = 0; i < nx+nh-1; i++) { *(rx++) = 0; } 
-        rx = r ;
-  	for ( i = 0; i < nx; i++) {
-        float xv = *xc++;
+  int i,n;
+  float xv = *x;
 
-  		for (j = 0; j < nh; j++) {
-  			*(rx + j) += xv * *(h + j);	
-  		}
-        rx++;
-  	}
+  for(i = 0; i < nh; i++) r[i] = xv * h[i];
+
+  for(n = 1; n < nx; n++){
+    xv = *(++x); r++;
+    for(i = 0; i < nh-1; i++) r[i] += xv * h[i];
+    r[i] = xv * h[i];
+  }
 }


### PR DESCRIPTION
float * rx, *xc: are inncessary varaibles because both x and r already are copies of the original pointers.

The new code makes nx*(nh+1) steps.
"""
  for(i = 0; i < nh; i++) r[i] = xv * h[i]; // nh steps

  /* nx * ( (nh-1) + 1) = nx *nh steps */
  for(n = 1; n < nx; n++){
    xv = *(++x); r++;
    for(i = 0; i < nh-1; i++) r[i] += xv * h[i];
    r[i] = xv * h[i];
  }
"""

While the last version makes nx*nh + nx + nh - 1 steps.

"""
for ( i = 0; i < nx+nh-1; i++) { *(rx++) = 0; }  // nx+nh-1 steps

/* nx*nh steps */
for ( i = 0; i < nx; i++) { 
  for (j = 0; j < nh; j++) {
    *(rx + j) += xv * *(h + j);	
  }
  rx++;
}
"""

Then, the new code is better.