### PR TITLE
math: Implement a basic "map" function for unary functions

### DIFF
--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -89,6 +89,48 @@
 //#define M_NORMALIZE_RADIANS(theta) (theta - (M_PI*2) * M_FLOOR((theta + M_PI) / (M_PI*2)))
 #define M_NORMALIZE_RADIANS(theta) ((float)(theta - (M_PI2) * M_FLOOR((theta + M_PI) * M_1_PI2)))
 
+/* Map a unary function onto an array */
+static inline void p_map_unary(float (*f)(const float),
+    const float *a, float *c, int n)
+{
+    int i, j;
+    const int N = 4;
+    const int k = n / N;
+    float a0, a1, a2, a3;
+    float c0, c1, c2, c3;
+    for (i = 0; i < k; i++) {
+        j = i * N;
+        a0 = a[j + 0];
+        a1 = a[j + 1];
+        a2 = a[j + 2];
+        a3 = a[j + 3];
+        c0 = (*f)(a0);
+        c1 = (*f)(a1);
+        c2 = (*f)(a2);
+        c3 = (*f)(a3);
+        c[j + 0] = c0;
+        c[j + 1] = c1;
+        c[j + 2] = c2;
+        c[j + 3] = c3;
+    }
+    switch (n % N) {
+        case 3:
+            c[k * N + 0] = (*f)(a[k * N + 0]);
+            c[k * N + 1] = (*f)(a[k * N + 1]);
+            c[k * N + 2] = (*f)(a[k * N + 2]);
+            break;
+        case 2:
+            c[k * N + 0] = (*f)(a[k * N + 0]);
+            c[k * N + 1] = (*f)(a[k * N + 1]);
+            break;
+        case 1:
+            c[k * N + 0] = (*f)(a[k * N + 0]);
+            break;
+        case 0:
+            break;
+    }
+}
+
 /*
  ****************************************************************
  * Basic Element Wise Vector Math Functions

--- a/include/pal_math.h
+++ b/include/pal_math.h
@@ -115,17 +115,11 @@ static inline void p_map_unary(float (*f)(const float),
     }
     switch (n % N) {
         case 3:
-            c[k * N + 0] = (*f)(a[k * N + 0]);
-            c[k * N + 1] = (*f)(a[k * N + 1]);
             c[k * N + 2] = (*f)(a[k * N + 2]);
-            break;
         case 2:
-            c[k * N + 0] = (*f)(a[k * N + 0]);
             c[k * N + 1] = (*f)(a[k * N + 1]);
-            break;
         case 1:
             c[k * N + 0] = (*f)(a[k * N + 0]);
-            break;
         case 0:
             break;
     }

--- a/src/math/p_acos.c
+++ b/src/math/p_acos.c
@@ -3,6 +3,7 @@
 #include "p_asin.h"
 
 /* acos z = pi/2 - asin z */
+static inline float _p_acos(const float z) __attribute__((always_inline));
 static inline float _p_acos(const float z)
 {
     return pi_2 - _p_asin(z);

--- a/src/math/p_acos.c
+++ b/src/math/p_acos.c
@@ -2,6 +2,12 @@
 
 #include "p_asin.h"
 
+/* acos z = pi/2 - asin z */
+static inline float _p_acos(const float z)
+{
+    return pi_2 - _p_asin(z);
+}
+
 /**
  *
  * Computes the inverse cosine (arc cosine) of the input vector 'a'. Input
@@ -19,10 +25,5 @@
  */
 void p_acos_f32(const float *a, float *c, int n)
 {
-
-    int i;
-    /* acos x = pi/2 - asin x */
-    for (i = 0; i < n; i++) {
-        c[i] = pi_2 - _p_asin(a[i]);
-    }
+    p_map_unary(&_p_acos, a, c, n);
 }

--- a/src/math/p_asin.c
+++ b/src/math/p_asin.c
@@ -19,9 +19,5 @@
  */
 void p_asin_f32(const float *a, float *c, int n)
 {
-
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_asin(a[i]);
-    }
+    p_map_unary(&_p_asin, a, c, n);
 }

--- a/src/math/p_asin.h
+++ b/src/math/p_asin.h
@@ -25,6 +25,7 @@ static inline float __p_asin_pos(const float x)
  * -1 <= x <= 1
  * asin(-x) = - asin x
  */
+static inline float _p_asin(const float x) __attribute__((always_inline));
 static inline float _p_asin(const float x)
 {
     if (x >= 0.f)

--- a/src/math/p_atan.c
+++ b/src/math/p_atan.c
@@ -5,6 +5,7 @@
  * atan x = a1 * x + a3 * x^3 + ... + a9 * x^9 + e(x)
  * |e(x)| <= 10^-5
  */
+static inline float _p_atan(const float x) __attribute__((always_inline));
 static inline float _p_atan(const float x)
 {
     const float a1 =  0.9998660f;

--- a/src/math/p_atan.c
+++ b/src/math/p_atan.c
@@ -36,9 +36,5 @@ static inline float _p_atan(const float x)
  */
 void p_atan_f32(const float *a, float *c, int n)
 {
-
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_atan(a[i]);
-    }
+    p_map_unary(&_p_atan, a, c, n);
 }

--- a/src/math/p_cosh.c
+++ b/src/math/p_cosh.c
@@ -28,9 +28,5 @@ static inline float _p_cosh(const float z)
 
 void p_cosh_f32(const float *a, float *c, int n)
 {
-
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_cosh(a[i]);
-    }
+    p_map_unary(&_p_cosh, a, c, n);
 }

--- a/src/math/p_cosh.c
+++ b/src/math/p_cosh.c
@@ -5,6 +5,7 @@
 /*
  * cosh z = (exp z + exp(-z)) / 2
  */
+static inline float _p_cosh(const float z) __attribute__((always_inline));
 static inline float _p_cosh(const float z)
 {
     float exp_z = _p_exp(z);

--- a/src/math/p_exp.c
+++ b/src/math/p_exp.c
@@ -17,9 +17,5 @@
  */
 void p_exp_f32(const float *a, float *c, int n)
 {
-
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_exp(a[i]);
-    }
+    p_map_unary(&_p_exp, a, c, n);
 }

--- a/src/math/p_sinh.c
+++ b/src/math/p_sinh.c
@@ -5,6 +5,7 @@
 /*
  * sinh z = (exp z - exp(-z)) / 2
  */
+static inline float _p_sinh(const float z) __attribute__((always_inline));
 static inline float _p_sinh(const float z)
 {
     float exp_z = _p_exp(z);

--- a/src/math/p_sinh.c
+++ b/src/math/p_sinh.c
@@ -27,8 +27,5 @@ static inline float _p_sinh(const float z)
  */
 void p_sinh_f32(const float *a, float *c, int n)
 {
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_sinh(a[i]);
-    }
+    p_map_unary(&_p_sinh, a, c, n);
 }

--- a/src/math/p_tan.c
+++ b/src/math/p_tan.c
@@ -60,6 +60,7 @@ static inline float __p_tan_pi(const float x)
 }
 
 /* 0 <= x <= 2pi */
+static inline float _p_tan(const float x) __attribute__((always_inline));
 static inline float _p_tan(const float x)
 {
     if (x <= pi)

--- a/src/math/p_tan.c
+++ b/src/math/p_tan.c
@@ -85,8 +85,5 @@ static inline float _p_tan(const float x)
  */
 void p_tan_f32(const float *a, float *c, int n)
 {
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_tan(a[i]);
-    }
+    p_map_unary(&_p_tan, a, c, n);
 }

--- a/src/math/p_tanh.c
+++ b/src/math/p_tanh.c
@@ -29,8 +29,5 @@ static inline float _p_tanh(const float z)
  */
 void p_tanh_f32(const float *a, float *c, int n)
 {
-    int i;
-    for (i = 0; i < n; i++) {
-        c[i] = _p_tanh(a[i]);
-    }
+    p_map_unary(&_p_tanh, a, c, n);
 }

--- a/src/math/p_tanh.c
+++ b/src/math/p_tanh.c
@@ -7,6 +7,7 @@
  *        = (exp z - exp -z) / (exp z + ezp -z)
  *        = (exp 2z - 1) / (exp 2z + 1)
  */
+static inline float _p_tanh(const float z) __attribute__((always_inline));
 static inline float _p_tanh(const float z)
 {
     float exp_2z = _p_exp(2.f * z);


### PR DESCRIPTION
Looking at the excellent work of @jar in the image processing algorithms, I wanted to do the same type of partial loop unrolling in the basic math functions. Working on four values at a time lets the compiler produce more vector arithmetic instructions.

This is a basic implementation of a "map" function, `p_map_unary`. It basically replaces a for loop. Its first argument is a pointer to a "pure" function that has a single argument. The other arguments are the input, output arrays, and array size, respectively.

I used it in some functions and it makes them larger but faster. Note that you should use the compiler flag `-march=native` to get the benefits of SIMD. (About 20% on x86.)