### PR TITLE
math: p_tan/p_atan: Optimised the number of multiplications.

### DIFF
--- a/src/math/p_atan.c
+++ b/src/math/p_atan.c
@@ -12,11 +12,8 @@ static inline float _p_atan(const float x)
     const float a5 =  0.1801410f;
     const float a7 = -0.0851330f;
     const float a9 =  0.0208351f;
-    return a1 * x +
-        a3 * x * x * x +
-        a5 * x * x * x * x * x +
-        a7 * x * x * x * x * x * x * x +
-        a9 * x * x * x * x * x * x * x * x * x;
+    float x2 = x * x;
+    return x * (a1 + x2 * (a3 + x2 * (a5 + x2 * (a7 + x2 * a9))));
 }
 
 /**

--- a/src/math/p_tan.c
+++ b/src/math/p_tan.c
@@ -20,13 +20,7 @@ static inline float __p_tan_pi_4(const float x)
     const float a12 = 0.0095168091f;
     float x2, tanx_x;
     x2 = x * x;
-    tanx_x = 1.f +
-         a2 * x2 +
-         a4 * x2 * x2 +
-         a6 * x2 * x2 * x2 +
-         a8 * x2 * x2 * x2 * x2 +
-        a10 * x2 * x2 * x2 * x2 * x2 +
-        a12 * x2 * x2 * x2 * x2 * x2 * x2;
+    tanx_x = 1.f + x2 * (a2 + x2 * (a4 + x2 * (a6 + x2 * (a8 + x2 * (a10 + x2 * a12)))));
     return tanx_x * x;
 }
 


### PR DESCRIPTION
__p_tan_pi_4 (the underlying function of p_tan) now uses 7
multiplications instead of 22. _p_atan now uses 6 instead of 25.
The number of additions for both functions remains the same.
Additionally, an extra float variable has been added to _p_atan,
which holds the square of x.

Signed-off-by: Ian Griffiths <6thimage@gmail.com>