### PR TITLE
image:p_median3x3: Don't subtract and cast to int

### DIFF
--- a/src/image/p_median3x3.c
+++ b/src/image/p_median3x3.c
@@ -1,15 +1,14 @@
 #include <pal.h>
 
-// Combined with subtraction, this magically works faster than if(a<b)
-#define gt0(f) ((*((int *) &(f))) > 0)
-
 #define SORT(a,b) \
 do { \
-	float d = a; \
-	float c = b - a; \
-	a = gt0(c) ? b : a; \
-	b = gt0(c) ? d : b; \
-} while(0) 
+	float d; \
+	if (a < b) { \
+		d = a; \
+		a = b; \
+		b = d; \
+	} \
+} while(0)
 
 static __inline __attribute__((__always_inline__))
 float my_median(
@@ -68,17 +67,8 @@ void p_median3x3_f32(const float *x, float *r, int rows, int cols)
 	}
 }
 
-#define SORT_HI(a,b) \
-do { \
-	float c = b - a; \
-	b = gt0(c) ? a : b; \
-} while(0)
-
-#define SORT_LO(a,b) \
-do { \
-	float c = b - a; \
-	a = gt0(c) ? b : a; \
-} while(0)
+#define SORT_HI(a,b) { if (b > a) b = a; }
+#define SORT_LO(a,b) { if (a < b) a = b; }
 
 /*
  * A specialized median 3x3 filter.


### PR DESCRIPTION
The Epiphany GCC backend emits a function call (__gtesf2) for float
comparisons unless -mno-soft-cmpsf is passed in. This is obviously
slower than doing an float subtraction + int comparison.

However, when compiled with "-O{,1,2,3,s} -mno-soft-cmpsf" this is
emitted:
```
1. fsub r2,r1,r0
2. movblte r1,r0
3. mov r0,r1
```

Float subtract + int cast & comparison:
```
1. fsub r2,r0,r1
2. sub r3,r2,#0
3. movgt r1,r0
4. mov r0,r1
```

Improved code for x86_64 and ARMv7 too.

Interactive example here:
http://goo.gl/jqiIdq
( http://gcc.parallella.org -- Godbolt :) )

```
Architecture  Speedup  CFLAGS
x86_64:       2.32     "-O3 -ffast-math -march=corei7-avx"
ARMv7:        1.28     "-O3 -ffast-math -mcpu=cortex-a9 -mfpu=neon"
Epiphany:     1.13     "-O2 -mno-soft-cmpsf -ffast-math
                        -mfp-mode=round-nearest -ffp-contract=fast"
```

Signed-off-by: Ola Jeppsson <ola@adapteva.com>