### PR TITLE
image:p_median3x3:removed subtract/integer compare

### DIFF
--- a/src/image/p_median3x3.c
+++ b/src/image/p_median3x3.c
@@ -1,15 +1,23 @@
 #include <pal.h>
 
-// Combined with subtraction, this magically works faster than if(a<b)
-#define gt0(f) ((*((int *) &(f))) > 0)
-
 #define SORT(a,b) \
 do { \
-	float d = a; \
-	float c = b - a; \
-	a = gt0(c) ? b : a; \
-	b = gt0(c) ? d : b; \
+	if (a < b) { \
+		float d = a; \
+		a = b; \
+		b = d; \
+	} \
 } while(0) 
+
+#define SORT_HI(a,b) \
+do { \
+	b = (a < b) ? a : b; \
+} while(0)
+
+#define SORT_LO(a,b) \
+do { \
+	a = (a < b) ? b : a; \
+} while(0)
 
 static __inline __attribute__((__always_inline__))
 float my_median(
@@ -67,18 +75,6 @@ void p_median3x3_f32(const float *x, float *r, int rows, int cols)
 		px += 2;
 	}
 }
-
-#define SORT_HI(a,b) \
-do { \
-	float c = b - a; \
-	b = gt0(c) ? a : b; \
-} while(0)
-
-#define SORT_LO(a,b) \
-do { \
-	float c = b - a; \
-	a = gt0(c) ? b : a; \
-} while(0)
 
 /*
  * A specialized median 3x3 filter.

--- a/src/math/p_cbrt.c
+++ b/src/math/p_cbrt.c
@@ -1,9 +1,11 @@
 #include <pal.h>
-#include <math.h>
 
 /**
  *
  * Calculates the cube root of the input vector 'a'.
+ *
+ * This is similar to the inverse cube root routine, p_invcbrt, with
+ * two extra multiplication operations in the last line of code. -JAR
  *
  * @param a     Pointer to input vector
  *
@@ -13,14 +15,24 @@
  *
  * @return      None
  *
- * @todo        Implement without using libm
- *
  */
 void p_cbrt_f32(const float *a, float *c, int n)
 {
-
-    int i;
-    for (i = 0; i < n; i++) {
-        *(c + i) = cbrtf(*(a + i));
-    }
+	int i;
+	float k = 1.33333333f;
+	for (i=0; i<n; i++) {
+		float a0 = *(a+i);
+		int j = *(int*)&a0;
+		int s = 0x80000000 & j;
+		j &= 0x7fffffff;
+		float a3 = 0.33333333f*(*(float*)&j);
+		int y = 0x54a2fa8e - 683*(j >> 11);
+		float x = *(float*)&y;
+		x *= k - a3*x*x*x;
+		x *= k - a3*x*x*x;
+		x *= k - a3*x*x*x;
+		int r = (s|(*(int*)&x));
+		float f = (*(float*)&r);
+		*(c+i) = a0*f*f;
+	}
 }


### PR DESCRIPTION
This patch is related to the poor compilation of the floating point comparison
operation.  The appropriate compiler flags (-mno-soft-cmpsf) must be enabled to
get the compiler to generate efficient code

Only minor formatting to the macros has been made and the code is logically
identical to the previous version.

Signed-off-by: James Ross <james.a.ross@gmail.com>