### PR TITLE
math: p_sum, p_sumsq: Improve loop performance

### DIFF
--- a/src/math/p_sum.c
+++ b/src/math/p_sum.c
@@ -17,10 +17,9 @@
 void p_sum_f32(const float *a, float *c, int n)
 {
     float tmp = 0.0f;
-    int i;
 
-    for (i = 0; i < n; i++) {
-        tmp += *(a + i);
+    for (; n > 0; n--) {
+        tmp += *(a++);
     }
     *c = tmp;
 }

--- a/src/math/p_sumsq.c
+++ b/src/math/p_sumsq.c
@@ -17,10 +17,9 @@
 void p_sumsq_f32(const float *a, float *c, int n)
 {
     float tmp = 0.0f;
-    int i;
 
-    for (i = 0; i < n; i++) {
-        tmp += *(a + i) * *(a + i);
+    for (; n > 0; n--) {
+        tmp += *(a) * *(a++);
     }
     *c = tmp;
 }


### PR DESCRIPTION
Change loop condition and pointer advancing for reduction of asm output (Epiphany) resulting in better performance.

compiled with the default `-O2 -ffast-math -mfp-mode=round-nearest
-ffp-contract=fast` on [gcc.parallella.org](http://gcc.parallella.org/)